### PR TITLE
feat: writing-specs-plugin v1.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -84,6 +84,11 @@
       "name": "local-test-plugin",
       "source": "./local-test-plugin",
       "description": "Symlink-based local plugin testing for development workflow"
+    },
+    {
+      "name": "writing-specs-plugin",
+      "source": "./writing-specs-plugin",
+      "description": "Spec-driven development with search, conflict detection, and reporting"
     }
   ]
 }

--- a/spec-manager-plugin/README.md
+++ b/spec-manager-plugin/README.md
@@ -1,3 +1,5 @@
+> **Deprecated**: Use `writing-specs-plugin` instead. This plugin is no longer maintained.
+
 # Spec Manager Plugin
 
 Manage specification files for spec-driven development workflow.

--- a/writing-specs-plugin/.claude-plugin/plugin.json
+++ b/writing-specs-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "writing-specs-plugin",
+  "description": "Spec-driven development with search, conflict detection, and reporting",
+  "version": "1.0.0",
+  "author": {
+    "name": "Stefan Cho"
+  }
+}

--- a/writing-specs-plugin/README.md
+++ b/writing-specs-plugin/README.md
@@ -1,0 +1,45 @@
+# Writing Specs Plugin
+
+Spec-driven development skill with conflict detection and reporting. Replaces `spec-manager-plugin`.
+
+## Installation
+
+```bash
+/plugin install writing-specs-plugin@devstefancho-claude-plugins
+```
+
+## Trigger Keywords
+
+- "스펙 생성해줘", "스펙 업데이트해줘", "스펙 작성해줘"
+- "create spec", "update spec", "write spec"
+
+## How It Works
+
+1. **Search** - Searches existing specs for conflicts/duplicates/outdated content
+2. **Decision** - Asks user how to proceed if related specs exist
+3. **Write** - Creates/updates spec using a fixed template (Purpose, Requirements, Approach, Verification)
+4. **Report** - Outputs a concise report of what was done
+
+## Directory Structure
+
+```
+specs/
+├── feature-name.md
+├── api/
+│   └── endpoint-auth.md
+└── auth/
+    └── jwt-tokens.md
+```
+
+- Files go in `specs/` with optional 1-depth subdirectories
+- Filenames use lowercase-with-hyphens
+
+## Differences from spec-manager-plugin
+
+| Feature | spec-manager | writing-specs |
+|---------|-------------|---------------|
+| Execution | Main context | Fork (subagent) |
+| Template | XML tags, 6 scope templates | Markdown headings, 1 universal template |
+| Conflict search | Basic duplicate check | Keyword search + outdated detection |
+| Report | None | Structured report after every operation |
+| Directory | `specs/{scope}/` | `specs/` with optional subdirs |

--- a/writing-specs-plugin/evals/evals.json
+++ b/writing-specs-plugin/evals/evals.json
@@ -1,0 +1,46 @@
+{
+  "skill_name": "writing-specs",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "JWT 토큰 기반 인증 시스템 스펙 생성해줘",
+      "expected_output": "specs/ 하위에 jwt 관련 spec.md 파일이 생성되고, 4개 섹션(Purpose, Requirements, Approach, Verification)이 모두 포함되며, 마지막에 Spec Report가 출력된다.",
+      "files": [],
+      "expectations": [
+        "A markdown file is created under specs/ directory",
+        "The file contains a '## Purpose' section with 1-2 sentences",
+        "The file contains a '## Requirements' section with bullet points",
+        "The file contains a '## Approach' section without code snippets",
+        "The file contains a '## Verification' section with bullet points",
+        "A Spec Report table is output with Action, File, and Title fields",
+        "The report includes a Search Results section"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "인증 관련 스펙 업데이트해줘 - OAuth2 지원 추가",
+      "expected_output": "기존 specs/jwt-authentication.md가 검색되어 발견되고, 사용자에게 업데이트/생성/취소 선택지가 제공된다.",
+      "files": [],
+      "expectations": [
+        "The skill searches for existing specs before proceeding",
+        "The existing jwt-authentication.md spec is found during search",
+        "The user is asked how to proceed (update existing or create new)",
+        "The report shows Action as 'Updated'",
+        "OAuth2 appears in the updated spec content"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "specs/api 디렉토리에 REST API 에러 핸들링 스펙 만들어줘",
+      "expected_output": "specs/api/ 1-depth 서브디렉토리가 생성되고 그 안에 스펙 파일이 작성된다.",
+      "files": [],
+      "expectations": [
+        "A subdirectory specs/api/ is created",
+        "The spec file is placed inside specs/api/ (not deeper)",
+        "The filename uses lowercase-with-hyphens format",
+        "All 4 template sections are present in the created file",
+        "The Spec Report correctly shows the file path under specs/api/"
+      ]
+    }
+  ]
+}

--- a/writing-specs-plugin/skills/writing-specs/SKILL.md
+++ b/writing-specs-plugin/skills/writing-specs/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: writing-specs
+description: Write and manage spec files with search, conflict detection, and reporting. Use when user asks to create a spec, update a spec, write a spec, or mentions 스펙 생성, 스펙 업데이트, 스펙 작성, 스펙 만들어줘. Proactively trigger whenever the user's request involves specification documents, even if they don't explicitly say "spec".
+allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion
+context: fork
+agent: general-purpose
+---
+
+# Writing Specs
+
+Manages spec files in `specs/` directory with conflict detection and concise reporting.
+
+## Principles
+
+1. **Template-driven** - Every spec follows the exact template structure. Never add extra sections or freestyle content. This prevents specs from becoming bloated documents that nobody reads.
+2. **Search first** - Always search for existing specs before creating or updating. This catches duplicates, conflicts, and outdated specs early.
+3. **One spec = one task** - Each spec covers a single unit of work. If a request spans multiple concerns, split into separate specs.
+4. **Concise by default** - Each section has strict limits: Purpose (1-2 sentences), Requirements (max 5 bullets), Approach (2-5 sentences, no code), Verification (max 5 bullets).
+5. **Report everything** - Every operation ends with a structured report so the user knows exactly what happened.
+
+## Directory Rules
+
+- Specs live in `specs/` at the project root
+- File format: `specs/{name}.md` or `specs/{subdir}/{name}.md`
+- Only 1-depth subdirectories allowed (e.g., `specs/api/auth.md` is OK, `specs/api/v2/auth.md` is NOT)
+- Filenames use lowercase-with-hyphens (e.g., `jwt-authentication.md`)
+- Create subdirectories only when the user explicitly requests grouping or when there are 5+ specs that share a clear category
+
+## Workflow
+
+### Phase 1: Search (mandatory)
+
+Before any create or update operation, search for existing specs:
+
+1. Run `Glob specs/**/*.md` to list all existing spec files
+2. Extract 3-5 key nouns from the user's request (skip generic words like "system", "feature", "add", "update")
+3. Run `Grep` for each keyword across all found spec files
+4. Classify results:
+   - **Exact match**: A spec covering the same topic already exists
+   - **Related**: A spec shares 2+ keywords or covers an adjacent topic
+   - **Outdated**: A spec references files/paths that no longer exist (verify with `Glob`)
+
+If no `specs/` directory exists yet, skip search and proceed to Phase 3.
+
+### Phase 2: Decision
+
+Based on search results:
+
+- **No related specs found** → Proceed to create
+- **Exact match found** → Ask user: "이미 동일한 스펙이 존재합니다: `{path}`. 업데이트할까요, 새로 생성할까요, 아니면 취소할까요?"
+- **Related specs found** → Show list and ask: "관련 스펙이 발견되었습니다. 어떻게 진행할까요?"
+- **Outdated specs found** → Inform user and offer to update: "다음 스펙이 outdated 상태입니다 (참조 파일 없음). 함께 업데이트할까요?"
+
+Use `AskUserQuestion` for all user decisions.
+
+### Phase 3: Write
+
+1. Read the spec template: [templates/spec-template.md](templates/spec-template.md)
+2. Fill each section based on the user's request, strictly following the template structure
+3. Write to the appropriate path under `specs/`
+4. If updating an existing spec, preserve any content the user didn't ask to change
+
+Section constraints (enforced, not suggested):
+- **Purpose**: Exactly 1-2 sentences. No bullet points.
+- **Requirements**: 3-5 bullet points. Each bullet is one concrete requirement.
+- **Approach**: 2-5 sentences in paragraph form. No code snippets.
+- **Verification**: 2-5 bullet points. Each describes a testable scenario.
+
+### Phase 4: Outdated Cleanup
+
+If outdated specs were found in Phase 1:
+- For each outdated spec, check what references are broken
+- Propose specific updates (do NOT auto-modify)
+- Only update after user confirmation
+
+### Phase 5: Report
+
+Read the report template and fill it in: [templates/report-template.md](templates/report-template.md)
+
+Output the completed report as the final message. This is how the user sees what happened.
+
+- **Action**: "Created" or "Updated"
+- **File**: Full relative path from project root
+- **Title**: The spec's H1 title
+- **Search Results**: List each related/outdated spec found, or "No related specs found"
+- **Changes**: For updates, summarize what changed. For new specs, say "New spec created"
+- **Next Steps**: One actionable suggestion (e.g., "Run implementation" or "Review related spec at specs/auth.md")

--- a/writing-specs-plugin/skills/writing-specs/templates/report-template.md
+++ b/writing-specs-plugin/skills/writing-specs/templates/report-template.md
@@ -1,0 +1,16 @@
+## Spec Report
+
+| Field | Value |
+|-------|-------|
+| Action | {Created / Updated} |
+| File | `{path}` |
+| Title | {title} |
+
+### Search Results
+- {related spec path} - {relationship}
+
+### Changes
+{diff summary or "New spec created"}
+
+### Next Steps
+- {1 actionable item}

--- a/writing-specs-plugin/skills/writing-specs/templates/spec-template.md
+++ b/writing-specs-plugin/skills/writing-specs/templates/spec-template.md
@@ -1,0 +1,17 @@
+# {title}
+
+## Purpose
+{1-2 sentences: what needs to be done and why}
+
+## Requirements
+- {requirement 1}
+- {requirement 2}
+- {requirement 3}
+
+## Approach
+{2-5 sentences: high-level technical approach, key decisions, constraints.
+No code. Focus on architecture and patterns.}
+
+## Verification
+- {verification 1}
+- {verification 2}


### PR DESCRIPTION
## Summary
- `writing-specs-plugin` 신규 생성: `context: fork` 기반 spec-driven development 스킬
- 단일 범용 템플릿 (Purpose, Requirements, Approach, Verification) 으로 간결한 스펙 작성
- 기존 스펙 검색/충돌 감지 + outdated 판별 + 구조화된 report 출력
- `spec-manager-plugin` deprecate 처리

## Test plan
- [x] Eval 3개 케이스 (create / update / subdir) with_skill 100% pass
- [x] without_skill 대비 pass rate +75% 향상 확인
- [ ] `/plugin install writing-specs-plugin@devstefancho-claude-plugins` 설치 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)