### PR TITLE
feat: create-team-plugin v1.0.0 - planner + implementer agent team

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -94,6 +94,11 @@
       "name": "brain-storm-plugin",
       "source": "./brain-storm-plugin",
       "description": "Brainstorm future features and improvements with wireframes and implementation detection"
+    },
+    {
+      "name": "create-team-plugin",
+      "source": "./create-team-plugin",
+      "description": "Auto-create planner + implementer agent team for worktree sessions"
     }
   ]
 }

--- a/create-team-plugin/.claude-plugin/plugin.json
+++ b/create-team-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "create-team-plugin",
+  "description": "Auto-create planner + implementer agent team for worktree sessions",
+  "version": "1.0.0",
+  "author": {
+    "name": "Stefan Cho"
+  }
+}

--- a/create-team-plugin/README.md
+++ b/create-team-plugin/README.md
@@ -1,0 +1,62 @@
+# create-team-plugin
+
+워크트리 세션에서 planner + implementer agent team을 자동 생성하는 스킬 플러그인.
+
+## 설치
+
+```bash
+/plugin marketplace add .
+/plugin install create-team-plugin@devstefancho-claude-plugins
+```
+
+## 사용법
+
+워크트리 세션에서 다음과 같이 트리거:
+
+```
+팀 생성해줘
+create team
+agent team 만들어줘
+```
+
+## 팀 구성
+
+| Member | Role | Color |
+|--------|------|-------|
+| team-lead | 오케스트레이션, 작업 할당 | - |
+| planner | 브레인스톰, spec 작성 | auto-assigned |
+| implementer | 코드 구현, 테스트 작성 | auto-assigned |
+
+## 작업 흐름
+
+```
+Goal → planner(spec) → TaskCreate → team-lead review → implementer(code) → Done
+```
+
+1. team-lead에게 목표를 설명
+2. planner가 `specs/` 디렉토리에 spec 작성
+3. planner가 구현 태스크 생성 (TaskCreate)
+4. team-lead가 리뷰 후 implementer에게 할당
+5. implementer가 spec 기반으로 코드 + 테스트 작성
+
+## 전제 조건
+
+- `claude -w`로 워크트리 세션 시작 필요
+- `writing-specs-plugin` 설치 권장 (planner의 spec 작성에 활용)
+
+## Teammate 1M Context 설정
+
+Teammate는 기본적으로 표준 Opus 모델(1M 아님)을 사용합니다. 1M context를 사용하려면:
+
+```bash
+export ANTHROPIC_DEFAULT_OPUS_MODEL='claude-opus-4-6[1m]'
+```
+
+`.zshrc`에 추가하면 영구 적용됩니다.
+
+## 자동 설정
+
+스킬 실행 시 자동으로 설정되는 항목:
+- Planner: `/loop 10m /writing-specs update spec`
+- Implementer: TaskList 주기적 확인
+- 색상: 자동 할당 (프로그래밍 설정 불가)

--- a/create-team-plugin/skills/create-team/SKILL.md
+++ b/create-team-plugin/skills/create-team/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: create-team
+description: Create an agent team with planner and implementer teammates for spec-driven development. Use when user says "create team", "팀 생성", "팀 만들어줘", "agent team", or wants to set up a planner+implementer workflow in a worktree session.
+allowed-tools: Bash, Agent, SendMessage, TeamCreate, TaskCreate, TaskList, TaskUpdate, Read, AskUserQuestion
+context: fork
+agent: general-purpose
+---
+
+# Create Team
+
+Creates a planner + implementer agent team for the current worktree session.
+
+## Workflow
+
+### Step 1: Determine team name
+
+Run `git branch --show-current` to get the current branch name. Convert to kebab-case team name:
+- Remove `worktree-` prefix if present
+- Replace `+` with `-`
+- Example: `worktree-feat+electron-app` → `feat-electron-app`
+
+### Step 2: Create the team
+
+Call `TeamCreate` with:
+- `team_name`: the derived team name
+- `description`: "Planner + Implementer team"
+
+### Step 3: Spawn teammates (parallel)
+
+Spawn both teammates **in parallel** using the Agent tool in a single message with two tool calls:
+
+**Planner:**
+- `team_name`: the team name
+- `name`: "planner"
+- `description`: "Planner - brainstorm and spec writing"
+- `prompt`: Read the full content of [templates/planner-prompt.md](templates/planner-prompt.md) and pass it as the prompt
+- `run_in_background`: true
+
+**Implementer:**
+- `team_name`: the team name
+- `name`: "implementer"
+- `description`: "Implementer - code and test writing"
+- `prompt`: Read the full content of [templates/implementer-prompt.md](templates/implementer-prompt.md) and pass it as the prompt
+- `run_in_background`: true
+
+### Step 4: Loop setup
+
+Send loop configuration via SendMessage:
+- To "planner": "Run `/loop 10m /writing-specs update spec` to periodically check and update specs."
+- To "implementer": "After completing assigned work, check TaskList for new tasks. You can run `/loop 10m check TaskList for unassigned tasks and report to team-lead` to automate this."
+
+### Step 5: Display work guide
+
+Read [templates/work-guide.md](templates/work-guide.md) and display the content to the user.
+Teammate colors are auto-assigned from a hardcoded palette and cannot be configured programmatically.
+
+## Fallback
+
+If Agent tool + `team_name` parameter fails with internal error (known issue anthropics/claude-code#40270):
+1. Inform the user about the issue
+2. Suggest spawning teammates manually:
+   - Open separate terminal windows
+   - Run `claude` in each with the planner/implementer prompts
+   - Use SendMessage for coordination
+
+## Notes
+
+- Teammates are full Claude Code sessions, not subagents
+- Both teammates can use all tools including Write, Edit, Bash
+- Both can run skills like `/writing-specs`, `/loop`
+- `/loop` is session-scoped and expires after 7 days
+- Teammate colors are auto-assigned from hardcoded palette (red, blue, green, yellow...) — not configurable
+- All communication flows through team-lead (planner <-> implementer direct messaging disabled by prompt rules)
+- Teammate model defaults to standard Opus (no 1M context). To use 1M context, set env var before starting: `export ANTHROPIC_DEFAULT_OPUS_MODEL='claude-opus-4-6[1m]'`

--- a/create-team-plugin/skills/create-team/templates/implementer-prompt.md
+++ b/create-team-plugin/skills/create-team/templates/implementer-prompt.md
@@ -1,0 +1,31 @@
+You are the **Implementer** teammate in an agent team.
+
+## Role
+
+You are responsible for code implementation and test writing based on specs. You do NOT write specs or do brainstorming.
+
+## Workflow
+
+1. **Wait for instructions** from team-lead. Do not start work autonomously.
+2. When you receive a task from team-lead:
+   a. Read the corresponding spec file from `specs/` directory first
+   b. Implement the feature/fix following the spec's Approach section
+   c. Write tests that validate the spec's Verification criteria
+   d. Mark the task as completed via `TaskUpdate`
+   e. Report completion to team-lead via `SendMessage`
+3. If you discover additional work needed during implementation, create new tasks via `TaskCreate`.
+4. After completing all assigned work, check `TaskList` for any remaining tasks assigned to you.
+
+## Communication Rules
+
+- **ONLY communicate with team-lead**. Do not send messages directly to planner.
+- Report to team-lead when:
+  - Implementation is completed
+  - Tests are passing
+  - You encounter blockers or need spec clarification
+  - You discover additional work that needs to be done
+  - All assigned work is done
+
+## Initial Behavior
+
+You are now ready and waiting for instructions from team-lead. Send a brief ready message to team-lead.

--- a/create-team-plugin/skills/create-team/templates/planner-prompt.md
+++ b/create-team-plugin/skills/create-team/templates/planner-prompt.md
@@ -1,0 +1,33 @@
+You are the **Planner** teammate in an agent team.
+
+## Role
+
+You are responsible for brainstorming, requirement analysis, and specification writing. You do NOT write code.
+
+## Workspace
+
+- Specs directory: `specs/` at the project root
+- Use the `/writing-specs` skill for spec creation and management
+
+## Workflow
+
+1. **Wait for instructions** from team-lead. Do not start work autonomously.
+2. When you receive a task from team-lead:
+   a. Analyze the requirements and brainstorm the approach
+   b. Use `/writing-specs` to create or update spec files in `specs/`
+   c. After completing the spec, create implementation tasks via `TaskCreate` with clear descriptions referencing the spec file path
+   d. Report completion to team-lead via `SendMessage`
+3. After completing all assigned work, check `TaskList` for any remaining tasks assigned to you.
+
+## Communication Rules
+
+- **ONLY communicate with team-lead**. Do not send messages directly to implementer.
+- Report to team-lead when:
+  - A spec is completed
+  - Implementation tasks have been created
+  - You encounter blockers or need clarification
+  - All assigned work is done
+
+## Initial Behavior
+
+You are now ready and waiting for instructions from team-lead. Send a brief ready message to team-lead.

--- a/create-team-plugin/skills/create-team/templates/work-guide.md
+++ b/create-team-plugin/skills/create-team/templates/work-guide.md
@@ -1,0 +1,40 @@
+## Agent Team Ready
+
+| Member | Role | Color |
+|--------|------|-------|
+| **team-lead** | You - orchestrate and assign work | - |
+| **planner** | Brainstorm, spec writing | auto-assigned |
+| **implementer** | Code implementation, test writing | auto-assigned |
+
+### How It Works
+
+```
+Goal -> planner(spec) -> TaskCreate -> team-lead review -> implementer(code) -> Done
+```
+
+1. Tell team-lead what you want to build
+2. Team-lead sends the goal to **planner**
+3. Planner writes specs in `specs/` and creates implementation tasks
+4. Team-lead reviews and assigns tasks to **implementer**
+5. Implementer reads specs, writes code + tests, marks tasks done
+
+### Message Routing
+
+자연어로 team-lead에게 요청하면 자동으로 적절한 teammate에게 전달합니다:
+- spec/기획/브레인스톰/요구사항 → **planner**
+- 코드/테스트/구현/배포 → **implementer**
+- 둘 다 필요한 경우 → **planner 먼저** (spec 완료 후 implementer)
+
+### Example Commands
+
+- "인증 기능 스펙 작성해줘" → planner에게 자동 전달
+- "login-api 구현해줘" → implementer에게 자동 전달
+- "TaskList 보여줘"
+- "팀 종료해줘"
+
+### Tips
+
+- Planner has `/loop 10m /writing-specs update spec` running for periodic spec maintenance
+- Agents go idle between turns - this is normal, send a message to wake them
+- All communication flows through team-lead (planner <-> implementer direct messaging disabled)
+- Use `TaskList` to check progress at any time


### PR DESCRIPTION
## Summary
- 워크트리 세션에서 planner + implementer agent team을 자동 생성하는 스킬 플러그인
- Planner: 브레인스톰, `/writing-specs` 기반 spec 작성, `/loop` 주기적 spec 관리
- Implementer: spec 기반 코드 구현 + 테스트 작성
- Team-lead가 자연어 요청을 자동 라우팅 (spec 관련 → planner, 코드 관련 → implementer)

## Test plan
- [ ] `/plugin marketplace add .` → `/plugin install create-team-plugin@devstefancho-claude-plugins`
- [ ] 워크트리에서 "팀 생성해줘" 트리거 확인
- [ ] TeamCreate + planner/implementer 스폰 확인
- [ ] Work guide 출력 확인
- [ ] SendMessage로 작업 지시 → teammate 응답 확인
- [ ] planner `/loop` 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)