### PR TITLE
fix: marketplace.json 파싱 에러 수정 및 gitignore 정리

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -100,6 +100,7 @@
       "source": "./implement-with-test-plugin",
       "description": "Implement code with tests from specs or direct requests"
     },
+    {
       "name": "brain-storm-plugin",
       "source": "./brain-storm-plugin",
       "description": "Brainstorm future features and improvements with wireframes and implementation detection"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 __pycache__/
 *.pyc
+.claude/
+.playwright-cli/
+plans/
+work-journal-plugin/

--- a/scripts/cldp.sh
+++ b/scripts/cldp.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# cldp - Claude Dev Plugin: fzf로 worktree 플러그인 선택 후 claude --plugin-dir 실행
+
+cldp() {
+  local base=~/works/claude-plugins/.claude/worktrees
+  local selected=$(
+    find "$base" -name ".claude-plugin" -type d -not -path "*/dist/*" 2>/dev/null \
+      | sed 's|/.claude-plugin$||' \
+      | sed "s|.*worktrees/||" \
+      | fzf --multi --prompt="Select plugin(s): "
+  )
+  [[ -z "$selected" ]] && return
+
+  local dirs=()
+  while IFS= read -r p; do
+    dirs+=(--plugin-dir "$base/$p")
+  done <<< "$selected"
+
+  claude "${dirs[@]}" "$@"
+}


### PR DESCRIPTION
## Summary
- marketplace.json에서 brain-storm-plugin 항목에 누락된 `{` 추가 (JSON 파싱 에러 수정)
- `.claude/`, `.playwright-cli/`, `plans/`, `work-journal-plugin/` gitignore 추가
- fzf 기반 worktree 플러그인 선택 스크립트(`scripts/cldp.sh`) 추가

## Test plan
- [ ] `/plugin` 마켓플레이스 로드 시 JSON 파싱 에러 없이 정상 표시되는지 확인
- [ ] `git status`에서 ignored 파일들이 표시되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)