### PR TITLE
feat: add hermes-gateway-plugin

### DIFF
--- a/hermes-gateway-plugin/.claude-plugin/plugin.json
+++ b/hermes-gateway-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "hermes",
+  "description": "Interact with Hermes Agent via local or SSH-tunneled connection",
+  "version": "1.0.0",
+  "author": {
+    "name": "Stefan Cho"
+  }
+}

--- a/hermes-gateway-plugin/commands/chat.md
+++ b/hermes-gateway-plugin/commands/chat.md
@@ -1,0 +1,16 @@
+---
+description: Hermes Agent에 메시지를 보내고 응답을 받는다
+argument-hint: "<message> [--stream] [--system 'system prompt']"
+allowed-tools: Bash(node:*), AskUserQuestion
+---
+
+Send a message to Hermes Agent and return the response.
+
+If no message was provided in `$ARGUMENTS`, use AskUserQuestion to ask what to send.
+
+Execute:
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/hermes-companion.mjs" chat $ARGUMENTS
+```
+
+Return the Hermes response verbatim. Do not paraphrase or summarize.

--- a/hermes-gateway-plugin/commands/jobs.md
+++ b/hermes-gateway-plugin/commands/jobs.md
@@ -1,0 +1,14 @@
+---
+description: Hermes cron job 목록 조회, 생성, 삭제
+argument-hint: "[list|delete <id>] [--json]"
+allowed-tools: Bash(node:*), AskUserQuestion
+---
+
+Manage Hermes cron jobs (scheduled automation tasks).
+
+Execute:
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/hermes-companion.mjs" jobs $ARGUMENTS
+```
+
+Return the output verbatim.

--- a/hermes-gateway-plugin/commands/run.md
+++ b/hermes-gateway-plugin/commands/run.md
@@ -1,0 +1,19 @@
+---
+description: Hermes Agent에 비동기 작업을 실행하고 이벤트를 스트리밍한다
+argument-hint: "<task> [--background]"
+allowed-tools: Bash(node:*), AskUserQuestion
+---
+
+Start an async run on Hermes Agent with event streaming.
+
+If no task was provided in `$ARGUMENTS`, use AskUserQuestion to ask what task to run.
+
+Execute:
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/hermes-companion.mjs" run $ARGUMENTS
+```
+
+- Without `--background`: stream events until completion and return output verbatim
+- With `--background`: return the job ID immediately so the user can check status later
+
+Return the output verbatim. Do not paraphrase or summarize.

--- a/hermes-gateway-plugin/commands/setup.md
+++ b/hermes-gateway-plugin/commands/setup.md
@@ -1,0 +1,45 @@
+---
+description: Hermes Agent 연결 설정 및 상태 확인 (로컬/SSH 모드 전환 지원)
+argument-hint: "[--mode auto|local|ssh] [--remote-host <host>] [--remote-port <port>] [--local-port <port>] [--api-key <key>]"
+allowed-tools: Bash(node:*), AskUserQuestion
+---
+
+Hermes 연결을 설정하고 상태를 확인한다.
+
+## 인자가 없는 경우
+
+연결 상태만 확인:
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/hermes-companion.mjs" setup
+```
+
+## 인자가 있는 경우
+
+config를 업데이트하고 연결 확인:
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/hermes-companion.mjs" setup $ARGUMENTS
+```
+
+## 사용자가 설정 변경을 요청하지만 구체적 값이 없는 경우
+
+AskUserQuestion으로 물어본다:
+- "어떤 모드로 변경할까요?" → choices: auto, local, ssh
+- SSH 모드 선택 시: "SSH 호스트 이름은?" (기본값: arch)
+
+## 사용 가능한 플래그
+
+- `--mode auto|local|ssh` — 연결 모드 변경
+- `--remote-host <host>` — SSH 원격 호스트 (기본: arch)
+- `--remote-port <port>` — 원격 Hermes 포트 (기본: 8642)
+- `--local-port <port>` — SSH 터널 로컬 포트 (기본: 18642)
+- `--api-key <key>` — Hermes API 키 설정
+
+## 예시
+
+- `/hermes:setup` → 현재 연결 상태 확인
+- `/hermes:setup --mode ssh` → SSH 모드로 전환
+- `/hermes:setup --mode ssh --remote-host myserver` → SSH 모드 + 호스트 변경
+- `/hermes:setup --mode local` → 로컬 모드로 전환
+- `/hermes:setup --mode auto` → 자동 감지 모드
+
+Config 파일 위치: `~/.claude/hermes/config.json`

--- a/hermes-gateway-plugin/commands/status.md
+++ b/hermes-gateway-plugin/commands/status.md
@@ -1,0 +1,14 @@
+---
+description: Hermes 연결 상태, tunnel 상태, 최근 작업 목록을 확인한다
+argument-hint: "[job-id] [--json]"
+allowed-tools: Bash(node:*)
+---
+
+Check Hermes connection health, tunnel status, and recent job history.
+
+Execute:
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/hermes-companion.mjs" status $ARGUMENTS
+```
+
+Return the output verbatim.

--- a/hermes-gateway-plugin/scripts/hermes-companion.mjs
+++ b/hermes-gateway-plugin/scripts/hermes-companion.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+
+import process from "node:process";
+import { resolve, loadConfig, saveConfig, killTunnel, getTunnelStatus } from "./lib/connection.mjs";
+import * as api from "./lib/hermes-api.mjs";
+import * as state from "./lib/state.mjs";
+import * as render from "./lib/render.mjs";
+
+function printUsage() {
+  console.log(
+    [
+      "Usage:",
+      "  hermes-companion.mjs setup [--json]",
+      "  hermes-companion.mjs chat <message> [--stream] [--system <prompt>] [--json]",
+      "  hermes-companion.mjs run <task> [--background] [--json]",
+      "  hermes-companion.mjs status [run-id] [--json]",
+      "  hermes-companion.mjs jobs [list|create|delete] [--json]",
+      "  hermes-companion.mjs tunnel [start|stop|status]",
+    ].join("\n")
+  );
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const command = args[0];
+  const flags = {};
+  const positional = [];
+
+  for (let i = 1; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--json") {
+      flags.json = true;
+    } else if (arg === "--stream") {
+      flags.stream = true;
+    } else if (arg === "--background") {
+      flags.background = true;
+    } else if (arg === "--system" && i + 1 < args.length) {
+      flags.system = args[++i];
+    } else if (arg === "--mode" && i + 1 < args.length) {
+      flags.mode = args[++i];
+    } else if (arg === "--host" && i + 1 < args.length) {
+      flags.host = args[++i];
+    } else if (arg === "--port" && i + 1 < args.length) {
+      flags.port = parseInt(args[++i], 10);
+    } else if (arg === "--remote-host" && i + 1 < args.length) {
+      flags.remoteHost = args[++i];
+    } else if (arg === "--remote-port" && i + 1 < args.length) {
+      flags.remotePort = parseInt(args[++i], 10);
+    } else if (arg === "--local-port" && i + 1 < args.length) {
+      flags.localPort = parseInt(args[++i], 10);
+    } else if (arg === "--api-key" && i + 1 < args.length) {
+      flags.apiKey = args[++i];
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  return { command, flags, positional, text: positional.join(" ") };
+}
+
+function output(value, asJson) {
+  if (asJson) {
+    console.log(JSON.stringify(value, null, 2));
+  } else if (typeof value === "string") {
+    process.stdout.write(value);
+  } else {
+    console.log(JSON.stringify(value, null, 2));
+  }
+}
+
+async function cmdSetup(flags) {
+  // If any config flags provided, update config first
+  const hasConfigChange = flags.mode || flags.host || flags.port || flags.remoteHost || flags.remotePort || flags.localPort || flags.apiKey !== undefined;
+
+  if (hasConfigChange) {
+    const config = loadConfig();
+    if (flags.mode) config.mode = flags.mode;
+    if (flags.host) config.local.host = flags.host;
+    if (flags.port) config.local.port = flags.port;
+    if (flags.remoteHost) config.ssh.remoteHost = flags.remoteHost;
+    if (flags.remotePort) config.ssh.remotePort = flags.remotePort;
+    if (flags.localPort) config.ssh.localPort = flags.localPort;
+    if (flags.apiKey !== undefined) config.apiKey = flags.apiKey || null;
+    saveConfig(config);
+    console.log(`Config updated: ${JSON.stringify(config, null, 2)}\n`);
+  }
+
+  const result = await resolve();
+  if (flags.json) {
+    output(result, true);
+  } else {
+    output(render.renderSetup(result), false);
+  }
+  process.exit(result.healthy ? 0 : 1);
+}
+
+async function cmdChat(flags, text) {
+  if (!text) {
+    console.error("Error: message is required. Usage: hermes-companion.mjs chat <message>");
+    process.exit(1);
+  }
+
+  const conn = await resolve();
+  if (!conn.healthy) {
+    console.error("Error: Cannot connect to Hermes. Run 'hermes-companion.mjs setup' first.");
+    process.exit(1);
+  }
+
+  const opts = { apiKey: conn.config.apiKey, system: flags.system };
+
+  if (flags.stream) {
+    const stream = await api.streamChat(conn.baseUrl, text, opts);
+    for await (const chunk of stream) {
+      if (chunk.type === "delta") {
+        process.stdout.write(chunk.content);
+      }
+    }
+    process.stdout.write("\n");
+  } else {
+    const result = await api.chat(conn.baseUrl, text, opts);
+    if (flags.json) {
+      output(result, true);
+    } else {
+      output(render.renderChat(result) + "\n", false);
+    }
+  }
+}
+
+async function cmdRun(flags, text) {
+  if (!text) {
+    console.error("Error: task is required. Usage: hermes-companion.mjs run <task>");
+    process.exit(1);
+  }
+
+  const conn = await resolve();
+  if (!conn.healthy) {
+    console.error("Error: Cannot connect to Hermes. Run 'hermes-companion.mjs setup' first.");
+    process.exit(1);
+  }
+
+  const opts = { apiKey: conn.config.apiKey };
+  const runInfo = await api.createRun(conn.baseUrl, text, opts);
+  const runId = runInfo.run_id || runInfo.id;
+  const jobRecord = state.createJobRecord(text, conn.mode);
+
+  if (flags.background) {
+    state.updateJobRecord(jobRecord.id, { runId, status: "background" });
+    if (flags.json) {
+      output({ jobId: jobRecord.id, runId, status: "started" }, true);
+    } else {
+      output(render.renderRunStarted(runInfo) + `\nJob ID: ${jobRecord.id}\n`, false);
+    }
+    return;
+  }
+
+  // Foreground: stream events
+  let fullOutput = "";
+  try {
+    for await (const event of api.streamRunEvents(conn.baseUrl, runId, opts)) {
+      const text = render.renderRunEvent(event);
+      if (text) {
+        process.stdout.write(text);
+        fullOutput += text;
+      }
+      state.appendLog(jobRecord.id, JSON.stringify(event));
+
+      if (event.event === "run.completed" || event.event === "run.failed") {
+        break;
+      }
+    }
+  } catch (err) {
+    console.error(`\nStream error: ${err.message}`);
+  }
+
+  state.updateJobRecord(jobRecord.id, { status: "completed", output: fullOutput });
+}
+
+async function cmdStatus(flags, text) {
+  const conn = await resolve();
+  const config = loadConfig();
+  const tunnel = getTunnelStatus(config);
+  const jobs = state.listJobRecords();
+
+  if (text) {
+    // status for a specific job/run
+    const job = state.readJobRecord(text);
+    if (job) {
+      output(flags.json ? job : JSON.stringify(job, null, 2), flags.json);
+    } else {
+      console.error(`Job not found: ${text}`);
+      process.exit(1);
+    }
+    return;
+  }
+
+  const statusInfo = {
+    connection: { mode: conn.mode, healthy: conn.healthy, baseUrl: conn.baseUrl },
+    tunnel,
+    jobs,
+  };
+
+  if (flags.json) {
+    output(statusInfo, true);
+  } else {
+    output(render.renderStatus(statusInfo) + "\n", false);
+  }
+}
+
+async function cmdJobs(flags, subcommand, text) {
+  const conn = await resolve();
+  if (!conn.healthy) {
+    console.error("Error: Cannot connect to Hermes. Run 'hermes-companion.mjs setup' first.");
+    process.exit(1);
+  }
+
+  const opts = { apiKey: conn.config.apiKey };
+  const sub = subcommand || "list";
+
+  if (sub === "list") {
+    const jobs = await api.listJobs(conn.baseUrl, opts);
+    if (flags.json) {
+      output(jobs, true);
+    } else {
+      output(render.renderJobs(Array.isArray(jobs) ? jobs : jobs.jobs || []) + "\n", false);
+    }
+  } else if (sub === "delete" && text) {
+    const result = await api.deleteJob(conn.baseUrl, text, opts);
+    output(flags.json ? result : `Job ${text} deleted.\n`, flags.json);
+  } else {
+    console.error("Usage: hermes-companion.mjs jobs [list|delete <id>]");
+    process.exit(1);
+  }
+}
+
+async function cmdTunnel(subcommand) {
+  const config = loadConfig();
+
+  if (subcommand === "stop") {
+    killTunnel();
+    console.log("Tunnel stopped.");
+  } else if (subcommand === "status") {
+    const status = getTunnelStatus(config);
+    console.log(JSON.stringify(status, null, 2));
+  } else {
+    // start
+    const { startTunnel } = await import("./lib/connection.mjs");
+    try {
+      const info = await startTunnel(config);
+      console.log(`Tunnel started. PID: ${info.pid}, URL: ${info.baseUrl}`);
+    } catch (err) {
+      console.error(`Failed: ${err.message}`);
+      process.exit(1);
+    }
+  }
+}
+
+async function main() {
+  const { command, flags, positional, text } = parseArgs(process.argv);
+
+  try {
+    switch (command) {
+      case "setup":
+        await cmdSetup(flags);
+        break;
+      case "chat":
+        await cmdChat(flags, text);
+        break;
+      case "run":
+        await cmdRun(flags, text);
+        break;
+      case "status":
+        await cmdStatus(flags, text);
+        break;
+      case "jobs":
+        await cmdJobs(flags, positional[0], positional.slice(1).join(" "));
+        break;
+      case "tunnel":
+        await cmdTunnel(positional[0]);
+        break;
+      default:
+        printUsage();
+        process.exit(command ? 1 : 0);
+    }
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/hermes-gateway-plugin/scripts/lib/connection.mjs
+++ b/hermes-gateway-plugin/scripts/lib/connection.mjs
@@ -1,0 +1,225 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn, execSync } from "node:child_process";
+
+const HERMES_DIR = path.join(os.homedir(), ".claude", "hermes");
+const CONFIG_FILE = path.join(HERMES_DIR, "config.json");
+const TUNNEL_PID_FILE = path.join(HERMES_DIR, "tunnel.pid");
+
+const DEFAULT_CONFIG = {
+  mode: "auto",
+  local: { host: "127.0.0.1", port: 8642 },
+  ssh: { remoteHost: "arch", remotePort: 8642, localPort: 18642 },
+  apiKey: null,
+};
+
+export function ensureHermesDir() {
+  fs.mkdirSync(path.join(HERMES_DIR, "jobs"), { recursive: true });
+  fs.mkdirSync(path.join(HERMES_DIR, "logs"), { recursive: true });
+}
+
+export function loadConfig() {
+  ensureHermesDir();
+  if (!fs.existsSync(CONFIG_FILE)) {
+    fs.writeFileSync(CONFIG_FILE, JSON.stringify(DEFAULT_CONFIG, null, 2));
+    return { ...DEFAULT_CONFIG };
+  }
+  try {
+    const raw = JSON.parse(fs.readFileSync(CONFIG_FILE, "utf8"));
+    return { ...DEFAULT_CONFIG, ...raw };
+  } catch {
+    return { ...DEFAULT_CONFIG };
+  }
+}
+
+export function saveConfig(config) {
+  ensureHermesDir();
+  fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
+}
+
+async function checkHealth(baseUrl, timeoutMs = 3000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${baseUrl}/health`, { signal: controller.signal });
+    clearTimeout(timer);
+    return res.ok;
+  } catch {
+    clearTimeout(timer);
+    return false;
+  }
+}
+
+function readTunnelPid() {
+  try {
+    const pid = parseInt(fs.readFileSync(TUNNEL_PID_FILE, "utf8").trim(), 10);
+    if (isNaN(pid)) return null;
+    try {
+      process.kill(pid, 0);
+      return pid;
+    } catch {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+function writeTunnelPid(pid) {
+  fs.writeFileSync(TUNNEL_PID_FILE, String(pid));
+}
+
+function clearTunnelPid() {
+  try {
+    fs.unlinkSync(TUNNEL_PID_FILE);
+  } catch {}
+}
+
+export async function startTunnel(config) {
+  const { ssh } = config;
+  const localUrl = `http://127.0.0.1:${ssh.localPort}`;
+
+  // Check if something is already listening on the local port
+  try {
+    const lsof = execSync(`lsof -ti :${ssh.localPort} -sTCP:LISTEN`, { encoding: "utf8" }).trim();
+    const existingPid = parseInt(lsof.split("\n")[0], 10);
+    if (!isNaN(existingPid)) {
+      // Something is listening - check if it's healthy
+      if (await checkHealth(localUrl)) {
+        writeTunnelPid(existingPid);
+        return { pid: existingPid, baseUrl: localUrl, reused: true };
+      }
+      // Listening but unhealthy - kill it
+      try { process.kill(existingPid, "SIGTERM"); } catch {}
+      clearTunnelPid();
+      await new Promise((r) => setTimeout(r, 300));
+    }
+  } catch {
+    // Nothing listening - proceed to create tunnel
+  }
+
+  const tunnelSpec = `${ssh.localPort}:127.0.0.1:${ssh.remotePort}`;
+  const TUNNEL_TIMEOUT_MS = 10000;
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`SSH tunnel timed out after ${TUNNEL_TIMEOUT_MS / 1000}s. Check: ssh ${ssh.remoteHost} works?`));
+      }
+    }, TUNNEL_TIMEOUT_MS);
+
+    const proc = spawn(
+      "ssh",
+      ["-fN", "-L", tunnelSpec, "-o", "StrictHostKeyChecking=accept-new", "-o", "ExitOnForwardFailure=yes", "-o", "ConnectTimeout=5", ssh.remoteHost],
+      { stdio: ["ignore", "ignore", "pipe"], detached: true }
+    );
+
+    let stderr = "";
+    proc.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
+
+    proc.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        reject(new Error(`SSH tunnel failed: ${err.message}`));
+      }
+    });
+
+    proc.on("exit", async (code) => {
+      if (settled) return;
+
+      if (code !== 0) {
+        settled = true;
+        clearTimeout(timer);
+        reject(new Error(`SSH tunnel exited with code ${code}${stderr ? `: ${stderr.trim()}` : ""}`));
+        return;
+      }
+
+      // ssh -f backgrounds itself; find the tunnel process
+      await new Promise((r) => setTimeout(r, 800));
+      try {
+        const lsof = execSync(`lsof -ti :${ssh.localPort} -sTCP:LISTEN`, { encoding: "utf8" }).trim();
+        const pid = parseInt(lsof.split("\n")[0], 10);
+        if (!isNaN(pid)) {
+          settled = true;
+          clearTimeout(timer);
+          writeTunnelPid(pid);
+          resolve({ pid, baseUrl: localUrl, reused: false });
+        } else {
+          settled = true;
+          clearTimeout(timer);
+          reject(new Error("SSH tunnel started but no process listening on port " + ssh.localPort));
+        }
+      } catch (e) {
+        settled = true;
+        clearTimeout(timer);
+        reject(new Error(`SSH tunnel started but could not verify: ${e.message}`));
+      }
+    });
+
+    proc.unref();
+  });
+}
+
+export function killTunnel() {
+  const pid = readTunnelPid();
+  if (pid) {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {}
+  }
+  clearTunnelPid();
+}
+
+export function getTunnelStatus(config) {
+  const pid = readTunnelPid();
+  return {
+    active: pid !== null,
+    pid,
+    localPort: config.ssh.localPort,
+    remoteHost: config.ssh.remoteHost,
+    remotePort: config.ssh.remotePort,
+  };
+}
+
+export async function resolve(configOverride) {
+  const config = configOverride || loadConfig();
+  const mode = config.mode || "auto";
+
+  if (mode === "local") {
+    const baseUrl = `http://${config.local.host}:${config.local.port}`;
+    const healthy = await checkHealth(baseUrl);
+    return { baseUrl, mode: "local", healthy, config };
+  }
+
+  if (mode === "ssh") {
+    let tunnelInfo;
+    try {
+      tunnelInfo = await startTunnel(config);
+    } catch (err) {
+      return { baseUrl: null, mode: "ssh", healthy: false, error: err.message, config };
+    }
+    const healthy = await checkHealth(tunnelInfo.baseUrl);
+    return { baseUrl: tunnelInfo.baseUrl, mode: "ssh", healthy, tunnel: tunnelInfo, config };
+  }
+
+  // auto mode: try local first, then ssh
+  const localUrl = `http://${config.local.host}:${config.local.port}`;
+  if (await checkHealth(localUrl)) {
+    return { baseUrl: localUrl, mode: "local", healthy: true, config };
+  }
+
+  try {
+    const tunnelInfo = await startTunnel(config);
+    const healthy = await checkHealth(tunnelInfo.baseUrl);
+    if (healthy) {
+      return { baseUrl: tunnelInfo.baseUrl, mode: "ssh", healthy: true, tunnel: tunnelInfo, config };
+    }
+    return { baseUrl: tunnelInfo.baseUrl, mode: "ssh", healthy: false, error: "Tunnel opened but Hermes health check failed", config };
+  } catch (err) {
+    return { baseUrl: null, mode: "none", healthy: false, error: `Local unavailable, SSH failed: ${err.message}`, config };
+  }
+}

--- a/hermes-gateway-plugin/scripts/lib/hermes-api.mjs
+++ b/hermes-gateway-plugin/scripts/lib/hermes-api.mjs
@@ -1,0 +1,188 @@
+export function makeHeaders(apiKey) {
+  const headers = { "Content-Type": "application/json" };
+  if (apiKey) {
+    headers["Authorization"] = `Bearer ${apiKey}`;
+  }
+  return headers;
+}
+
+export async function healthCheck(baseUrl, apiKey) {
+  const res = await fetch(`${baseUrl}/health`, { headers: makeHeaders(apiKey) });
+  if (!res.ok) throw new Error(`Health check failed: ${res.status}`);
+  return await res.json();
+}
+
+export async function chat(baseUrl, messages, options = {}) {
+  const { apiKey, system, stream = false } = options;
+
+  const body = {
+    model: "hermes-agent",
+    messages: [],
+    stream,
+  };
+
+  if (system) {
+    body.messages.push({ role: "system", content: system });
+  }
+
+  if (typeof messages === "string") {
+    body.messages.push({ role: "user", content: messages });
+  } else {
+    body.messages.push(...messages);
+  }
+
+  const res = await fetch(`${baseUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: makeHeaders(apiKey),
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Chat failed (${res.status}): ${text}`);
+  }
+
+  if (!stream) {
+    const data = await res.json();
+    return {
+      content: data.choices?.[0]?.message?.content ?? "",
+      model: data.model,
+      usage: data.usage,
+      finishReason: data.choices?.[0]?.finish_reason,
+    };
+  }
+
+  return res;
+}
+
+export async function streamChat(baseUrl, messages, options = {}) {
+  const res = await chat(baseUrl, messages, { ...options, stream: true });
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let fullContent = "";
+
+  return {
+    async *[Symbol.asyncIterator]() {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed || !trimmed.startsWith("data: ")) continue;
+          const data = trimmed.slice(6);
+          if (data === "[DONE]") return;
+
+          try {
+            const parsed = JSON.parse(data);
+            const delta = parsed.choices?.[0]?.delta?.content;
+            if (delta) {
+              fullContent += delta;
+              yield { type: "delta", content: delta };
+            }
+          } catch {}
+        }
+      }
+    },
+    getFullContent() {
+      return fullContent;
+    },
+  };
+}
+
+export async function createRun(baseUrl, input, options = {}) {
+  const { apiKey, instructions, sessionId, previousResponseId } = options;
+
+  const body = { input };
+  if (instructions) body.instructions = instructions;
+  if (sessionId) body.session_id = sessionId;
+  if (previousResponseId) body.previous_response_id = previousResponseId;
+
+  const res = await fetch(`${baseUrl}/v1/runs`, {
+    method: "POST",
+    headers: makeHeaders(apiKey),
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Create run failed (${res.status}): ${text}`);
+  }
+
+  return await res.json();
+}
+
+export async function* streamRunEvents(baseUrl, runId, options = {}) {
+  const { apiKey } = options;
+
+  const res = await fetch(`${baseUrl}/v1/runs/${runId}/events`, {
+    headers: makeHeaders(apiKey),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Stream events failed (${res.status}): ${text}`);
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() || "";
+
+    let currentEvent = null;
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("event: ")) {
+        currentEvent = trimmed.slice(7);
+      } else if (trimmed.startsWith("data: ")) {
+        const data = trimmed.slice(6);
+        try {
+          const parsed = JSON.parse(data);
+          yield { event: currentEvent || parsed.event, ...parsed };
+        } catch {}
+        currentEvent = null;
+      }
+    }
+  }
+}
+
+export async function listJobs(baseUrl, options = {}) {
+  const { apiKey } = options;
+  const res = await fetch(`${baseUrl}/api/jobs`, { headers: makeHeaders(apiKey) });
+  if (!res.ok) throw new Error(`List jobs failed: ${res.status}`);
+  return await res.json();
+}
+
+export async function createJob(baseUrl, job, options = {}) {
+  const { apiKey } = options;
+  const res = await fetch(`${baseUrl}/api/jobs`, {
+    method: "POST",
+    headers: makeHeaders(apiKey),
+    body: JSON.stringify(job),
+  });
+  if (!res.ok) throw new Error(`Create job failed: ${res.status}`);
+  return await res.json();
+}
+
+export async function deleteJob(baseUrl, jobId, options = {}) {
+  const { apiKey } = options;
+  const res = await fetch(`${baseUrl}/api/jobs/${jobId}`, {
+    method: "DELETE",
+    headers: makeHeaders(apiKey),
+  });
+  if (!res.ok) throw new Error(`Delete job failed: ${res.status}`);
+  return await res.json();
+}

--- a/hermes-gateway-plugin/scripts/lib/render.mjs
+++ b/hermes-gateway-plugin/scripts/lib/render.mjs
@@ -1,0 +1,109 @@
+export function renderSetup(result) {
+  const lines = [];
+  lines.push("# Hermes Gateway Status\n");
+
+  const modeLabel = result.mode === "local" ? "Local" : result.mode === "ssh" ? "SSH" : result.mode;
+  lines.push(`**Mode:** ${modeLabel}`);
+
+  if (result.healthy) {
+    lines.push(`**URL:** ${result.baseUrl}`);
+    lines.push(`**Status:** Connected\n`);
+
+    if (result.tunnel) {
+      lines.push(`**Tunnel PID:** ${result.tunnel.pid}`);
+      lines.push(`**Tunnel reused:** ${result.tunnel.reused ? "Yes" : "No"}`);
+    }
+  } else {
+    lines.push(`**Status:** Not connected`);
+    if (result.baseUrl) {
+      lines.push(`**URL:** ${result.baseUrl}`);
+    }
+    if (result.error) {
+      lines.push(`**Error:** ${result.error}`);
+    }
+    if (result.tunnel) {
+      lines.push(`**Tunnel:** opened (PID ${result.tunnel.pid}) but Hermes not responding`);
+    }
+    lines.push("\n## Troubleshooting\n");
+    if (result.mode === "ssh" || result.mode === "none") {
+      lines.push("1. Verify SSH works: `ssh arch`");
+      lines.push("2. Check remote Hermes: `ssh arch \"curl -s http://127.0.0.1:8642/health\"`");
+      lines.push("3. Start remote Hermes: `ssh arch \"hermes gateway start\"`");
+    }
+    if (result.mode === "local" || result.mode === "none") {
+      lines.push("1. Check if Hermes is running: `hermes gateway status`");
+      lines.push("2. Start Hermes: `hermes gateway start`");
+    }
+    lines.push(`\nConfig: \`~/.claude/hermes/config.json\``);
+  }
+
+  return lines.join("\n");
+}
+
+export function renderChat(result) {
+  return result.content || "(empty response)";
+}
+
+export function renderRunStarted(runInfo) {
+  const lines = [];
+  lines.push(`**Run started:** ${runInfo.run_id || runInfo.id}`);
+  lines.push(`**Status:** ${runInfo.status}`);
+  return lines.join("\n");
+}
+
+export function renderRunEvent(event) {
+  switch (event.event) {
+    case "message.delta":
+      return event.delta || "";
+    case "tool.started":
+      return `\n[Tool: ${event.tool || "unknown"} started]\n`;
+    case "tool.completed":
+      return `\n[Tool: ${event.tool || "unknown"} completed (${event.duration_ms || 0}ms)]\n`;
+    case "reasoning.available":
+      return `\n<thinking>${event.content || ""}</thinking>\n`;
+    case "run.completed":
+      return `\n---\n**Run completed.** Output: ${event.output || "(none)"}\n`;
+    case "run.failed":
+      return `\n---\n**Run failed.** Error: ${event.error || "unknown"}\n`;
+    default:
+      return "";
+  }
+}
+
+export function renderStatus(statusInfo) {
+  const lines = [];
+  lines.push("# Hermes Status\n");
+
+  if (statusInfo.connection) {
+    lines.push(`**Connection:** ${statusInfo.connection.mode} (${statusInfo.connection.healthy ? "healthy" : "unhealthy"})`);
+  }
+
+  if (statusInfo.tunnel) {
+    lines.push(`**Tunnel:** ${statusInfo.tunnel.active ? "active" : "inactive"} (PID: ${statusInfo.tunnel.pid || "none"})`);
+  }
+
+  if (statusInfo.jobs && statusInfo.jobs.length > 0) {
+    lines.push("\n## Recent Jobs\n");
+    lines.push("| ID | Status | Created |");
+    lines.push("|---|---|---|");
+    for (const job of statusInfo.jobs.slice(-10)) {
+      lines.push(`| ${job.id} | ${job.status} | ${job.createdAt} |`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function renderJobs(jobs) {
+  if (!jobs || jobs.length === 0) {
+    return "No cron jobs found.";
+  }
+
+  const lines = ["# Hermes Cron Jobs\n"];
+  lines.push("| ID | Schedule | Status |");
+  lines.push("|---|---|---|");
+  for (const job of jobs) {
+    lines.push(`| ${job.id || job.job_id} | ${job.schedule || job.cron || "N/A"} | ${job.status || "active"} |`);
+  }
+  return lines.join("\n");
+}

--- a/hermes-gateway-plugin/scripts/lib/state.mjs
+++ b/hermes-gateway-plugin/scripts/lib/state.mjs
@@ -1,0 +1,109 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+const HERMES_DIR = path.join(os.homedir(), ".claude", "hermes");
+const JOBS_DIR = path.join(HERMES_DIR, "jobs");
+const LOGS_DIR = path.join(HERMES_DIR, "logs");
+const MANIFEST_FILE = path.join(JOBS_DIR, "manifest.json");
+const MAX_JOBS = 50;
+
+function ensureDirs() {
+  fs.mkdirSync(JOBS_DIR, { recursive: true });
+  fs.mkdirSync(LOGS_DIR, { recursive: true });
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+export function generateJobId() {
+  return `hermes-${Date.now()}-${randomUUID().slice(0, 8)}`;
+}
+
+function loadManifest() {
+  try {
+    return JSON.parse(fs.readFileSync(MANIFEST_FILE, "utf8"));
+  } catch {
+    return { jobs: [] };
+  }
+}
+
+function saveManifest(manifest) {
+  ensureDirs();
+  // prune old jobs
+  if (manifest.jobs.length > MAX_JOBS) {
+    manifest.jobs = manifest.jobs.slice(-MAX_JOBS);
+  }
+  fs.writeFileSync(MANIFEST_FILE, JSON.stringify(manifest, null, 2));
+}
+
+export function createJobRecord(input, mode) {
+  ensureDirs();
+  const id = generateJobId();
+  const record = {
+    id,
+    input,
+    mode,
+    status: "running",
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
+    output: null,
+    error: null,
+  };
+
+  fs.writeFileSync(path.join(JOBS_DIR, `${id}.json`), JSON.stringify(record, null, 2));
+
+  const manifest = loadManifest();
+  manifest.jobs.push({ id, status: "running", createdAt: record.createdAt });
+  saveManifest(manifest);
+
+  return record;
+}
+
+export function updateJobRecord(id, updates) {
+  const jobFile = path.join(JOBS_DIR, `${id}.json`);
+  try {
+    const record = JSON.parse(fs.readFileSync(jobFile, "utf8"));
+    Object.assign(record, updates, { updatedAt: nowIso() });
+    fs.writeFileSync(jobFile, JSON.stringify(record, null, 2));
+
+    const manifest = loadManifest();
+    const entry = manifest.jobs.find((j) => j.id === id);
+    if (entry && updates.status) {
+      entry.status = updates.status;
+    }
+    saveManifest(manifest);
+
+    return record;
+  } catch {
+    return null;
+  }
+}
+
+export function readJobRecord(id) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(JOBS_DIR, `${id}.json`), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export function listJobRecords() {
+  const manifest = loadManifest();
+  return manifest.jobs;
+}
+
+export function appendLog(id, line) {
+  ensureDirs();
+  fs.appendFileSync(path.join(LOGS_DIR, `${id}.log`), line + "\n");
+}
+
+export function readLog(id) {
+  try {
+    return fs.readFileSync(path.join(LOGS_DIR, `${id}.log`), "utf8");
+  } catch {
+    return "";
+  }
+}

--- a/hermes-gateway-plugin/skills/hermes-runtime/SKILL.md
+++ b/hermes-gateway-plugin/skills/hermes-runtime/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: hermes-runtime
+description: Internal helper contract for calling the hermes-companion runtime from Claude Code
+user-invocable: false
+---
+
+# Hermes Runtime
+
+Use this skill only inside hermes-gateway plugin commands and subagents.
+
+Primary helper:
+- `node "${CLAUDE_PLUGIN_ROOT}/scripts/hermes-companion.mjs" <subcommand> <args>`
+
+Available subcommands:
+- `setup [--json]` - Check connectivity (auto-detects local vs SSH mode)
+- `chat <message> [--stream] [--system <prompt>] [--json]` - Send message to Hermes
+- `run <task> [--background] [--json]` - Start async run with event streaming
+- `status [job-id] [--json]` - Check connection/job status
+- `jobs [list|delete <id>] [--json]` - Manage cron jobs
+- `tunnel [start|stop|status]` - Manage SSH tunnel directly
+
+Execution rules:
+- Prefer the helper over hand-rolled SSH, curl, or HTTP commands
+- Return stdout verbatim without paraphrasing or summarizing
+- Do not inspect files, monitor progress, or do follow-up work
+- If the helper reports connectivity failure, suggest running `/hermes:setup`
+
+Connection modes:
+- **auto** (default): tries localhost:8642 first, then SSH tunnel
+- **local**: direct connection to localhost:8642
+- **ssh**: SSH tunnel to remote host (default: `arch`)
+- Config file: `~/.claude/hermes/config.json`


### PR DESCRIPTION
## Summary
- Hermes Agent (NousResearch) 연동 플러그인 추가
- 로컬/SSH 듀얼 모드 지원 (auto 감지)
- Commands: `/hermes:setup`, `/hermes:chat`, `/hermes:run`, `/hermes:status`, `/hermes:jobs`

## Test plan
- [x] 72개 자동화 테스트 통과 (vitest)
- [x] 로컬 모드 연결 확인
- [x] SSH 모드 터널 + 연결 확인
- [x] chat 스트리밍 동작 확인
- [x] `--plugin-dir`로 실제 플러그인 커맨드 테스트 (4/4 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)