### PR TITLE
feat: redesign plugin store website UI/UX

### DIFF
--- a/scripts/generate-plugin-data.js
+++ b/scripts/generate-plugin-data.js
@@ -193,8 +193,8 @@ function generatePluginData() {
         category: categoryId,
         components,
         features,
-        installCommand: `/plugin install ${dir}@devstefancho-claude-plugins`,
-        uninstallCommand: `/plugin uninstall ${dir}@devstefancho-claude-plugins`,
+        installCommand: `/plugin install ${metadata.name || dir}@devstefancho-claude-plugins`,
+        uninstallCommand: `/plugin uninstall ${metadata.name || dir}@devstefancho-claude-plugins`,
         readmePath: `${dir}/README.md`,
         hasReadme: fs.existsSync(path.join(rootDir, dir, 'README.md'))
       })

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
       lang: 'en',
       themeConfig: {
         nav: [
-          { text: 'Home', link: '/' },
           { text: 'Plugins', link: '/plugins/' },
           { text: 'Guide', link: '/guide/getting-started' }
         ],
@@ -41,7 +40,6 @@ export default defineConfig({
       link: '/ko/',
       themeConfig: {
         nav: [
-          { text: '홈', link: '/ko/' },
           { text: '플러그인', link: '/ko/plugins/' },
           { text: '가이드', link: '/ko/guide/getting-started' }
         ],
@@ -81,10 +79,6 @@ export default defineConfig({
     socialLinks: [
       { icon: 'github', link: 'https://github.com/devstefancho/claude-plugins' }
     ],
-
-    search: {
-      provider: 'local'
-    },
 
     footer: {
       message: 'Released under the MIT License.',

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -87,7 +87,10 @@ export default defineConfig({
   },
 
   head: [
-    ['link', { rel: 'icon', href: '/favicon.ico' }]
+    ['link', { rel: 'icon', href: '/favicon.ico' }],
+    ['link', { rel: 'preconnect', href: 'https://fonts.googleapis.com' }],
+    ['link', { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' }],
+    ['link', { href: 'https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap', rel: 'stylesheet' }]
   ],
 
   markdown: {

--- a/website/.vitepress/theme/components/HeroSection.vue
+++ b/website/.vitepress/theme/components/HeroSection.vue
@@ -1,0 +1,339 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { ChevronRight, Sparkles } from 'lucide-vue-next'
+import pluginData from '../../../data/plugins.json'
+
+const props = defineProps<{
+  lang?: 'ko' | 'en'
+}>()
+
+const pluginCount = pluginData.plugins.length
+const categoryCount = pluginData.categories.length
+
+const isVisible = ref(false)
+onMounted(() => {
+  requestAnimationFrame(() => { isVisible.value = true })
+})
+
+const labels = {
+  en: {
+    title: 'Claude Plugins',
+    tagline: 'Extend Claude Code with community-built plugins',
+    stats: `${pluginCount} plugins across ${categoryCount} categories`,
+    browse: '> Browse Plugins',
+    getStarted: 'Get Started',
+    terminalTitle: 'Terminal',
+    terminalComment: '# Install a plugin in seconds',
+  },
+  ko: {
+    title: 'Claude Plugins',
+    tagline: '커뮤니티가 만든 플러그인으로 Claude Code를 확장하세요',
+    stats: `${categoryCount}개 카테고리에 ${pluginCount}개 플러그인`,
+    browse: '> 플러그인 둘러보기',
+    getStarted: '시작하기',
+    terminalTitle: '터미널',
+    terminalComment: '# 몇 초 만에 플러그인 설치',
+  }
+}
+
+const t = labels[props.lang || 'en']
+</script>
+
+<template>
+  <section :class="['hero-section', { visible: isVisible }]">
+    <div class="hero-bg">
+      <div class="dot-grid"></div>
+    </div>
+
+    <div class="hero-content">
+      <div class="hero-left">
+        <div class="hero-badge">
+          <Sparkles :size="14" />
+          <span>{{ t.stats }}</span>
+        </div>
+
+        <h1 class="hero-title">{{ t.title }}</h1>
+        <p class="hero-tagline">{{ t.tagline }}</p>
+
+        <div class="hero-actions">
+          <a :href="lang === 'ko' ? '/ko/plugins/' : '/en/plugins/'" class="btn-terminal">
+            <span class="btn-terminal-text">{{ t.browse }}</span>
+            <span class="cursor-blink">_</span>
+          </a>
+          <a :href="lang === 'ko' ? '/ko/guide/getting-started' : '/en/guide/getting-started'" class="btn-secondary-hero">
+            {{ t.getStarted }}
+            <ChevronRight :size="16" />
+          </a>
+        </div>
+      </div>
+
+      <div class="hero-right">
+        <div class="terminal-window">
+          <div class="terminal-header">
+            <div class="terminal-dots">
+              <span class="dot red"></span>
+              <span class="dot yellow"></span>
+              <span class="dot green"></span>
+            </div>
+            <span class="terminal-title">{{ t.terminalTitle }}</span>
+          </div>
+          <div class="terminal-body">
+            <div class="terminal-line comment">{{ t.terminalComment }}</div>
+            <div class="terminal-line">
+              <span class="prompt">$</span>
+              <span class="command">/plugin marketplace add</span>
+              <span class="arg">devstefancho/claude-plugins</span>
+            </div>
+            <div class="terminal-line success">
+              <span class="prompt">&check;</span>
+              <span>Marketplace registered</span>
+            </div>
+            <div class="terminal-line mt">
+              <span class="prompt">$</span>
+              <span class="command">/plugin install</span>
+              <span class="arg">code-style-plugin</span>
+              <span class="cursor-blink">_</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.hero-section {
+  position: relative;
+  padding: 5rem 2rem 4rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.hero-section.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.hero-bg {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.dot-grid {
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(circle, var(--vp-c-text-3) 0.5px, transparent 0.5px);
+  background-size: 28px 28px;
+  opacity: 0.15;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4rem;
+  align-items: center;
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 1rem;
+  background: var(--cat-amber-soft, rgba(212, 165, 116, 0.1));
+  border: 1px solid var(--cat-amber-border, rgba(212, 165, 116, 0.25));
+  border-radius: 100px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: var(--vp-c-brand-1);
+  margin-bottom: 1.5rem;
+}
+
+.hero-title {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 3.5rem;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1.1;
+  color: var(--vp-c-text-1);
+  margin: 0 0 1rem 0;
+}
+
+.hero-tagline {
+  font-size: 1.2rem;
+  color: var(--vp-c-text-2);
+  line-height: 1.6;
+  margin: 0 0 2rem 0;
+  max-width: 480px;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.btn-terminal {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.75rem 1.75rem;
+  background: var(--vp-c-text-1);
+  color: var(--vp-c-bg);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.95rem;
+  font-weight: 500;
+  border-radius: 10px;
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.btn-terminal:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+}
+
+.btn-secondary-hero {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.75rem 1.5rem;
+  color: var(--vp-c-text-1);
+  font-size: 0.95rem;
+  font-weight: 500;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 10px;
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.btn-secondary-hero:hover {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-brand-1);
+}
+
+@keyframes blink {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+
+.cursor-blink {
+  animation: blink 1s step-end infinite;
+  color: var(--vp-c-brand-1);
+  font-weight: 700;
+}
+
+/* Terminal Window */
+.terminal-window {
+  background: #1a1a2e;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2), 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.dark .terminal-window {
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.terminal-header {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  background: rgba(255, 255, 255, 0.03);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.terminal-dots {
+  display: flex;
+  gap: 6px;
+  margin-right: 1rem;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.dot.red { background: #ff5f57; }
+.dot.yellow { background: #febc2e; }
+.dot.green { background: #28c840; }
+
+.terminal-title {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.terminal-body {
+  padding: 1.25rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  line-height: 1.8;
+}
+
+.terminal-line {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.terminal-line.mt {
+  margin-top: 0.5rem;
+}
+
+.terminal-line.comment {
+  color: rgba(255, 255, 255, 0.3);
+  font-style: italic;
+}
+
+.terminal-line.success {
+  color: #4ade80;
+  margin-bottom: 0.25rem;
+}
+
+.prompt {
+  color: #d4a574;
+  flex-shrink: 0;
+}
+
+.command {
+  color: #e8e4df;
+}
+
+.arg {
+  color: #818cf8;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero-content {
+    grid-template-columns: 1fr;
+    gap: 2.5rem;
+  }
+
+  .hero-title {
+    font-size: 2.5rem;
+  }
+
+  .hero-tagline {
+    font-size: 1.05rem;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hero-right {
+    order: -1;
+  }
+}
+</style>

--- a/website/.vitepress/theme/components/HomeFeatures.vue
+++ b/website/.vitepress/theme/components/HomeFeatures.vue
@@ -1,70 +1,96 @@
 <script setup lang="ts">
-import { Code2, GitBranch, FileText, Wrench } from 'lucide-vue-next'
+import { computed } from 'vue'
+import { Code2, GitBranch, FileText, Wrench, Server, ChevronRight } from 'lucide-vue-next'
+import pluginData from '../../../data/plugins.json'
 
 const props = defineProps<{
   lang?: 'ko' | 'en'
 }>()
 
-const features = {
-  ko: [
+const plugins = pluginData.plugins
+
+const features = computed(() => {
+  const lang = props.lang || 'en'
+  const countByCategory = (catId: string) => plugins.filter(p => p.category === catId).length
+
+  return [
     {
       icon: Code2,
-      title: '코드 리뷰 & 품질',
-      details: 'DRY, KISS, Clean Code 원칙 기반의 자동 코드 리뷰'
+      catId: 'code-review',
+      title: lang === 'ko' ? '코드 리뷰 & 품질' : 'Code Review & Quality',
+      details: lang === 'ko' ? 'DRY, KISS, Clean Code 원칙 기반의 자동 코드 리뷰' : 'Automated code review based on DRY, KISS, Clean Code principles',
+      count: countByCategory('code-review'),
+      browseLabel: lang === 'ko' ? '둘러보기' : 'Browse',
     },
     {
       icon: GitBranch,
-      title: '개발 워크플로우',
-      details: 'Git 커밋, PR 생성, 워킹트리 관리 자동화'
+      catId: 'workflow',
+      title: lang === 'ko' ? '개발 워크플로우' : 'Development Workflow',
+      details: lang === 'ko' ? 'Git 커밋, PR 생성, 워킹트리 관리 자동화' : 'Automate Git commits, PR creation, worktree management',
+      count: countByCategory('workflow'),
+      browseLabel: lang === 'ko' ? '둘러보기' : 'Browse',
     },
     {
       icon: FileText,
-      title: '사양 & 계획',
-      details: 'SDD 워크플로우, 스펙 파일 관리'
+      catId: 'specification',
+      title: lang === 'ko' ? '사양 & 계획' : 'Specification & Planning',
+      details: lang === 'ko' ? 'SDD 워크플로우, 스펙 파일 관리' : 'SDD workflow, spec file management',
+      count: countByCategory('specification'),
+      browseLabel: lang === 'ko' ? '둘러보기' : 'Browse',
     },
     {
       icon: Wrench,
-      title: '유틸리티',
-      details: '세션 리포트, 알림 등 편의 기능'
-    }
-  ],
-  en: [
-    {
-      icon: Code2,
-      title: 'Code Review & Quality',
-      details: 'Automated code review based on DRY, KISS, Clean Code principles'
+      catId: 'utility',
+      title: lang === 'ko' ? '유틸리티' : 'Utilities',
+      details: lang === 'ko' ? '세션 리포트, 알림, 에이전트 팀 관리 등' : 'Session reports, notifications, agent team management, and more',
+      count: countByCategory('utility'),
+      browseLabel: lang === 'ko' ? '둘러보기' : 'Browse',
     },
     {
-      icon: GitBranch,
-      title: 'Development Workflow',
-      details: 'Automate Git commits, PR creation, worktree management'
-    },
-    {
-      icon: FileText,
-      title: 'Specification & Planning',
-      details: 'SDD workflow, spec file management'
-    },
-    {
-      icon: Wrench,
-      title: 'Utilities',
-      details: 'Session reports, notifications, and more'
+      icon: Server,
+      catId: 'infrastructure',
+      title: lang === 'ko' ? '인프라' : 'Infrastructure',
+      details: lang === 'ko' ? '공유 MCP 서버 및 도구 통합' : 'Shared MCP servers and tool integrations',
+      count: countByCategory('infrastructure'),
+      browseLabel: lang === 'ko' ? '둘러보기' : 'Browse',
     }
   ]
+})
+
+const getPluginPagePath = (catId: string) => {
+  const base = props.lang === 'ko' ? '/ko/plugins/' : '/en/plugins/'
+  return `${base}?category=${catId}`
 }
 
-const currentFeatures = props.lang === 'ko' ? features.ko : features.en
+const sectionTitle = computed(() =>
+  props.lang === 'ko' ? '플러그인으로 무엇을 할 수 있나요?' : 'What can plugins do?'
+)
 </script>
 
 <template>
   <div class="home-features">
+    <h2 class="features-section-title">{{ sectionTitle }}</h2>
     <div class="features-container">
-      <div v-for="(feature, index) in currentFeatures" :key="index" class="feature-card">
-        <div class="feature-icon">
-          <component :is="feature.icon" :size="24" />
+      <a
+        v-for="feature in features"
+        :key="feature.catId"
+        :href="getPluginPagePath(feature.catId)"
+        class="feature-card"
+        :data-cat="feature.catId"
+      >
+        <div class="feature-icon" :data-cat="feature.catId">
+          <component :is="feature.icon" :size="26" />
         </div>
-        <h3 class="feature-title">{{ feature.title }}</h3>
+        <div class="feature-header">
+          <h3 class="feature-title">{{ feature.title }}</h3>
+          <span class="feature-count">{{ feature.count }}</span>
+        </div>
         <p class="feature-details">{{ feature.details }}</p>
-      </div>
+        <span class="feature-link">
+          {{ feature.browseLabel }}
+          <ChevronRight :size="14" />
+        </span>
+      </a>
     </div>
   </div>
 </template>

--- a/website/.vitepress/theme/components/InstallBanner.vue
+++ b/website/.vitepress/theme/components/InstallBanner.vue
@@ -1,0 +1,203 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { Copy, Check, X } from 'lucide-vue-next'
+
+const props = defineProps<{
+  lang?: 'ko' | 'en'
+}>()
+
+const command = '/plugin marketplace add devstefancho/claude-plugins'
+const copied = ref(false)
+const dismissed = ref(true)
+
+onMounted(() => {
+  if (typeof window !== 'undefined') {
+    dismissed.value = localStorage.getItem('install-banner-dismissed') === 'true'
+  }
+})
+
+const copyCommand = async () => {
+  try {
+    await navigator.clipboard.writeText(command)
+    copied.value = true
+    setTimeout(() => { copied.value = false }, 2000)
+  } catch (err) {
+    console.error('Failed to copy:', err)
+  }
+}
+
+const dismiss = () => {
+  dismissed.value = true
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('install-banner-dismissed', 'true')
+  }
+}
+
+const labels = {
+  en: {
+    prefix: 'First time?',
+    desc: 'Register the marketplace to get started:',
+    copied: 'Copied!',
+    copy: 'Copy',
+  },
+  ko: {
+    prefix: '처음이신가요?',
+    desc: '마켓플레이스를 먼저 등록하세요:',
+    copied: '복사됨!',
+    copy: '복사',
+  }
+}
+
+const t = labels[props.lang || 'en']
+</script>
+
+<template>
+  <div v-if="!dismissed" class="install-banner">
+    <div class="banner-content">
+      <div class="banner-text">
+        <span class="banner-prefix">{{ t.prefix }}</span>
+        <span class="banner-desc">{{ t.desc }}</span>
+      </div>
+      <div class="banner-command">
+        <code class="command-text">
+          <span class="prompt">$</span>
+          {{ command }}
+        </code>
+        <button class="banner-copy" @click="copyCommand">
+          <Check v-if="copied" :size="14" />
+          <Copy v-else :size="14" />
+          {{ copied ? t.copied : t.copy }}
+        </button>
+      </div>
+    </div>
+    <button class="banner-close" @click="dismiss" :aria-label="lang === 'ko' ? '닫기' : 'Close'">
+      <X :size="16" />
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.install-banner {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background: #1a1a2e;
+  border-radius: 10px;
+  margin-bottom: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.banner-content {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.banner-text {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+
+.banner-prefix {
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: #d4a574;
+}
+
+.banner-desc {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.banner-command {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.command-text {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: #e8e4df;
+  white-space: nowrap;
+}
+
+.command-text .prompt {
+  color: #4ade80;
+  margin-right: 0.5rem;
+}
+
+.banner-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.625rem;
+  background: rgba(255, 255, 255, 0.1);
+  border: none;
+  border-radius: 4px;
+  color: rgba(255, 255, 255, 0.7);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background 0.15s ease;
+  white-space: nowrap;
+}
+
+.banner-copy:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.banner-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.3);
+  cursor: pointer;
+  border-radius: 4px;
+  transition: color 0.15s ease;
+  flex-shrink: 0;
+}
+
+.banner-close:hover {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+@media (max-width: 768px) {
+  .install-banner {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .banner-content {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .banner-command {
+    overflow-x: auto;
+  }
+
+  .banner-close {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+  }
+
+  .install-banner {
+    position: relative;
+    padding-right: 2.5rem;
+  }
+}
+</style>

--- a/website/.vitepress/theme/components/PluginCard.vue
+++ b/website/.vitepress/theme/components/PluginCard.vue
@@ -80,19 +80,33 @@ const getCategoryIcon = (categoryId: string) => {
 
 <template>
   <!-- Card View -->
-  <article v-if="view !== 'list'" class="plugin-card">
+  <article v-if="view !== 'list'" class="plugin-card" :data-category="plugin.category">
     <div class="plugin-card-header">
       <div class="plugin-card-meta">
-        <span class="plugin-card-category">
-          <component :is="getCategoryIcon(plugin.category)" :size="16" />
+        <span class="plugin-card-category" :data-cat="plugin.category">
+          <component :is="getCategoryIcon(plugin.category)" :size="12" />
+          {{ getCategoryName(plugin.category) }}
         </span>
         <span class="plugin-card-version">v{{ plugin.version }}</span>
       </div>
+      <a :href="`https://github.com/devstefancho/claude-plugins/tree/main/${plugin.id}`" target="_blank" class="detail-link" :title="lang === 'en' ? 'View on GitHub' : 'GitHub에서 보기'">
+        <ExternalLink :size="14" />
+      </a>
     </div>
 
     <div class="plugin-card-content">
       <h3 class="plugin-card-title">{{ plugin.name }}</h3>
       <p class="plugin-card-description">{{ plugin.description }}</p>
+    </div>
+
+    <!-- Install command preview with copy -->
+    <div class="install-command-preview" @click="copyInstallCommand">
+      <span class="prompt">$</span>
+      <span class="cmd">{{ plugin.installCommand }}</span>
+      <button class="cmd-copy-btn" @click.stop="copyInstallCommand">
+        <Check v-if="copied" :size="13" />
+        <Copy v-else :size="13" />
+      </button>
     </div>
 
     <ul v-if="plugin.features.length > 0" class="plugin-card-features">
@@ -121,27 +135,14 @@ const getCategoryIcon = (categoryId: string) => {
       </span>
     </div>
 
-    <div class="plugin-card-actions">
-      <button class="btn btn-primary" @click="copyInstallCommand">
-        <Copy v-if="!copied" :size="14" />
-        <Check v-else :size="14" />
-        {{ copied ? (lang === 'en' ? 'Copied!' : '복사됨!') : (lang === 'en' ? 'Install' : '설치') }}
-      </button>
-      <a :href="`https://github.com/devstefancho/claude-plugins/tree/main/${plugin.id}`" target="_blank" class="btn btn-ghost">
-        {{ lang === 'en' ? 'Details' : '상세' }}
-        <ExternalLink :size="14" />
-      </a>
-    </div>
   </article>
 
   <!-- List View -->
-  <article v-else class="plugin-card plugin-card-list">
-    <!-- Left: Icon -->
+  <article v-else class="plugin-card plugin-card-list" :data-category="plugin.category">
     <span class="plugin-list-icon">
       <component :is="getCategoryIcon(plugin.category)" :size="18" />
     </span>
 
-    <!-- Center: Main content -->
     <div class="plugin-list-main">
       <div class="plugin-list-title-row">
         <h3 class="plugin-card-title">{{ plugin.name }}</h3>
@@ -150,7 +151,6 @@ const getCategoryIcon = (categoryId: string) => {
       <p class="plugin-card-description">{{ plugin.description }}</p>
     </div>
 
-    <!-- Right: Badges + Actions -->
     <div class="plugin-list-right">
       <div class="plugin-card-badges">
         <span v-if="plugin.components.skills.length > 0" class="badge badge-skill">

--- a/website/.vitepress/theme/components/PluginList.vue
+++ b/website/.vitepress/theme/components/PluginList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import { Search, Package, LayoutGrid, List } from 'lucide-vue-next'
 import pluginData from '../../../data/plugins.json'
 import PluginCard from './PluginCard.vue'
@@ -30,6 +30,46 @@ const searchQuery = ref('')
 const selectedCategory = ref('')
 const selectedComponent = ref('')
 const viewMode = ref<'card' | 'list'>('card')
+
+// URL parameter sync
+function readUrlParams() {
+  if (typeof window === 'undefined') return
+  const params = new URLSearchParams(window.location.search)
+  searchQuery.value = params.get('search') || ''
+  selectedCategory.value = params.get('category') || ''
+  selectedComponent.value = params.get('component') || ''
+  const view = params.get('view')
+  if (view === 'list' || view === 'card') {
+    viewMode.value = view
+  }
+}
+
+function updateUrlParams() {
+  if (typeof window === 'undefined') return
+  const params = new URLSearchParams()
+  if (searchQuery.value) params.set('search', searchQuery.value)
+  if (selectedCategory.value) params.set('category', selectedCategory.value)
+  if (selectedComponent.value) params.set('component', selectedComponent.value)
+  if (viewMode.value !== 'card') params.set('view', viewMode.value)
+
+  const queryString = params.toString()
+  const newUrl = window.location.pathname + (queryString ? '?' + queryString : '')
+  window.history.replaceState({}, '', newUrl)
+}
+
+onMounted(() => {
+  readUrlParams()
+})
+
+// Debounced search URL sync
+let searchDebounceTimer: ReturnType<typeof setTimeout>
+watch(searchQuery, () => {
+  clearTimeout(searchDebounceTimer)
+  searchDebounceTimer = setTimeout(updateUrlParams, 300)
+})
+
+// Immediate URL sync for non-search filters
+watch([selectedCategory, selectedComponent, viewMode], updateUrlParams)
 
 const categories = pluginData.categories
 const plugins = pluginData.plugins as Plugin[]

--- a/website/.vitepress/theme/components/PluginList.vue
+++ b/website/.vitepress/theme/components/PluginList.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { Search, Package, LayoutGrid, List } from 'lucide-vue-next'
 import pluginData from '../../../data/plugins.json'
 import PluginCard from './PluginCard.vue'
+import InstallBanner from './InstallBanner.vue'
 
 const props = defineProps<{
   lang?: 'ko' | 'en'
@@ -30,6 +31,24 @@ const searchQuery = ref('')
 const selectedCategory = ref('')
 const selectedComponent = ref('')
 const viewMode = ref<'card' | 'list'>('card')
+const searchInputRef = ref<HTMLInputElement | null>(null)
+
+// Keyboard shortcut: "/" to focus search
+const handleKeydown = (e: KeyboardEvent) => {
+  if (e.key === '/' && !['INPUT', 'TEXTAREA', 'SELECT'].includes((e.target as HTMLElement)?.tagName)) {
+    e.preventDefault()
+    searchInputRef.value?.focus()
+  }
+}
+
+onMounted(() => {
+  readUrlParams()
+  document.addEventListener('keydown', handleKeydown)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleKeydown)
+})
 
 // URL parameter sync
 function readUrlParams() {
@@ -57,10 +76,6 @@ function updateUrlParams() {
   window.history.replaceState({}, '', newUrl)
 }
 
-onMounted(() => {
-  readUrlParams()
-})
-
 // Debounced search URL sync
 let searchDebounceTimer: ReturnType<typeof setTimeout>
 watch(searchQuery, () => {
@@ -74,17 +89,18 @@ watch([selectedCategory, selectedComponent, viewMode], updateUrlParams)
 const categories = pluginData.categories
 const plugins = pluginData.plugins as Plugin[]
 
-const categoryNames = {
-  'code-review': { ko: '코드 리뷰 & 품질', en: 'Code Review & Quality' },
-  'workflow': { ko: '개발 워크플로우', en: 'Development Workflow' },
-  'specification': { ko: '사양 & 계획', en: 'Specification & Planning' },
+const categoryNames: Record<string, { ko: string; en: string }> = {
+  'code-review': { ko: '코드 리뷰 & 품질', en: 'Code Review' },
+  'workflow': { ko: '워크플로우', en: 'Workflow' },
+  'specification': { ko: '사양 & 계획', en: 'Specification' },
   'utility': { ko: '유틸리티', en: 'Utilities' },
   'infrastructure': { ko: '인프라', en: 'Infrastructure' }
 }
 
+const categoryCount = (catId: string) => plugins.filter(p => p.category === catId).length
+
 const filteredPlugins = computed(() => {
   return plugins.filter(plugin => {
-    // Search filter
     if (searchQuery.value) {
       const query = searchQuery.value.toLowerCase()
       const matchesSearch =
@@ -94,12 +110,10 @@ const filteredPlugins = computed(() => {
       if (!matchesSearch) return false
     }
 
-    // Category filter
     if (selectedCategory.value && plugin.category !== selectedCategory.value) {
       return false
     }
 
-    // Component filter
     if (selectedComponent.value) {
       switch (selectedComponent.value) {
         case 'skills':
@@ -131,6 +145,10 @@ const clearFilters = () => {
   selectedComponent.value = ''
 }
 
+const toggleCategory = (catId: string) => {
+  selectedCategory.value = selectedCategory.value === catId ? '' : catId
+}
+
 const getCategoryLabel = (categoryId: string) => {
   const lang = props.lang || 'en'
   return categoryNames[categoryId]?.[lang] || categoryId
@@ -139,39 +157,37 @@ const getCategoryLabel = (categoryId: string) => {
 const labels = computed(() => {
   const lang = props.lang || 'en'
   return {
-    searchPlaceholder: lang === 'ko' ? '플러그인 검색...' : 'Search plugins...',
-    allCategories: lang === 'ko' ? '모든 카테고리' : 'All Categories',
+    searchPlaceholder: lang === 'ko' ? '> 플러그인 검색...' : '> search plugins...',
+    allCategories: lang === 'ko' ? '전체' : 'All',
     allComponents: lang === 'ko' ? '모든 컴포넌트' : 'All Components',
     pluginCount: lang === 'ko'
-      ? `총 ${filteredPlugins.value.length}개의 플러그인`
-      : `${filteredPlugins.value.length} plugins found`,
+      ? `${filteredPlugins.value.length}개의 플러그인`
+      : `${filteredPlugins.value.length} plugins`,
     clearFilters: lang === 'ko' ? '필터 초기화' : 'Clear filters',
-    noPlugins: lang === 'ko' ? '플러그인을 찾을 수 없습니다' : 'No plugins found'
+    noPlugins: lang === 'ko' ? '검색 결과가 없습니다' : 'No plugins found',
+    noPluginsHint: lang === 'ko' ? '다른 키워드로 검색해 보세요' : 'Try a different search term'
   }
 })
 </script>
 
 <template>
   <div class="plugin-list">
+    <InstallBanner :lang="lang" />
+
     <div class="plugin-list-header">
       <div class="search-container">
         <Search :size="18" class="search-icon" />
         <input
+          ref="searchInputRef"
           type="text"
           v-model="searchQuery"
           :placeholder="labels.searchPlaceholder"
           class="search-input"
         />
+        <kbd class="search-kbd">/</kbd>
       </div>
 
       <div class="filter-group">
-        <select v-model="selectedCategory" class="filter-select">
-          <option value="">{{ labels.allCategories }}</option>
-          <option v-for="cat in categories" :key="cat.id" :value="cat.id">
-            {{ getCategoryLabel(cat.id) }}
-          </option>
-        </select>
-
         <select v-model="selectedComponent" class="filter-select">
           <option value="">{{ labels.allComponents }}</option>
           <option value="skills">Skills</option>
@@ -199,6 +215,28 @@ const labels = computed(() => {
       </div>
     </div>
 
+    <!-- Category pills -->
+    <div class="category-pills">
+      <button
+        :class="['category-pill', { active: !selectedCategory }]"
+        data-cat="all"
+        @click="selectedCategory = ''"
+      >
+        {{ labels.allCategories }}
+        <span class="pill-count">({{ plugins.length }})</span>
+      </button>
+      <button
+        v-for="cat in categories"
+        :key="cat.id"
+        :class="['category-pill', { active: selectedCategory === cat.id }]"
+        :data-cat="cat.id"
+        @click="toggleCategory(cat.id)"
+      >
+        {{ getCategoryLabel(cat.id) }}
+        <span class="pill-count">({{ categoryCount(cat.id) }})</span>
+      </button>
+    </div>
+
     <div class="plugin-results-meta">
       <span class="plugin-count">{{ labels.pluginCount }}</span>
       <button v-if="hasActiveFilters" @click="clearFilters" class="clear-filters">
@@ -219,6 +257,7 @@ const labels = computed(() => {
     <div v-else class="empty-state">
       <Package :size="48" />
       <p>{{ labels.noPlugins }}</p>
+      <p style="font-size: 0.85rem; margin-top: 0.5rem;">{{ labels.noPluginsHint }}</p>
     </div>
   </div>
 </template>

--- a/website/.vitepress/theme/components/StatsBar.vue
+++ b/website/.vitepress/theme/components/StatsBar.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+import { computed, ref, onMounted } from 'vue'
+import { Package, Layers, Brain, Terminal, Webhook, Plug } from 'lucide-vue-next'
+import pluginData from '../../../data/plugins.json'
+
+const props = defineProps<{
+  lang?: 'ko' | 'en'
+}>()
+
+const plugins = pluginData.plugins
+
+const stats = computed(() => {
+  const totalSkills = plugins.reduce((sum, p) => sum + p.components.skills.length, 0)
+  const totalCommands = plugins.reduce((sum, p) => sum + p.components.commands.length, 0)
+  const totalHooks = plugins.filter(p => p.components.hooks).length
+  const totalMcp = plugins.reduce((sum, p) => sum + p.components.mcpServers.length, 0)
+
+  return [
+    { icon: Package, value: plugins.length, label: 'Plugins', labelKo: '플러그인' },
+    { icon: Layers, value: pluginData.categories.length, label: 'Categories', labelKo: '카테고리' },
+    { icon: Brain, value: totalSkills, label: 'Skills', labelKo: '스킬' },
+    { icon: Terminal, value: totalCommands, label: 'Commands', labelKo: '커맨드' },
+    { icon: Webhook, value: totalHooks, label: 'Hooks', labelKo: '훅' },
+    { icon: Plug, value: totalMcp, label: 'MCP Servers', labelKo: 'MCP 서버' },
+  ]
+})
+
+const isVisible = ref(false)
+onMounted(() => {
+  const observer = new IntersectionObserver(
+    ([entry]) => {
+      if (entry.isIntersecting) {
+        isVisible.value = true
+        observer.disconnect()
+      }
+    },
+    { threshold: 0.3 }
+  )
+  const el = document.querySelector('.stats-bar')
+  if (el) observer.observe(el)
+})
+</script>
+
+<template>
+  <div :class="['stats-bar', { visible: isVisible }]">
+    <div class="stats-container">
+      <div v-for="(stat, i) in stats" :key="stat.label" class="stat-item" :style="{ animationDelay: `${i * 80}ms` }">
+        <component :is="stat.icon" :size="16" class="stat-icon" />
+        <span class="stat-value">{{ stat.value }}</span>
+        <span class="stat-label">{{ lang === 'ko' ? stat.labelKo : stat.label }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.stats-bar {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 2rem 3rem;
+}
+
+.stats-container {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  padding: 1.25rem 2rem;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-border-soft);
+  border-radius: 12px;
+  flex-wrap: wrap;
+}
+
+.stat-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+}
+
+.stats-bar.visible .stat-item {
+  opacity: 1;
+  transform: translateY(0);
+  transition-delay: var(--delay, 0ms);
+}
+
+.stats-bar.visible .stat-item:nth-child(1) { transition-delay: 0ms; }
+.stats-bar.visible .stat-item:nth-child(2) { transition-delay: 80ms; }
+.stats-bar.visible .stat-item:nth-child(3) { transition-delay: 160ms; }
+.stats-bar.visible .stat-item:nth-child(4) { transition-delay: 240ms; }
+.stats-bar.visible .stat-item:nth-child(5) { transition-delay: 320ms; }
+.stats-bar.visible .stat-item:nth-child(6) { transition-delay: 400ms; }
+
+.stat-icon {
+  color: var(--vp-c-brand-1);
+  flex-shrink: 0;
+}
+
+.stat-value {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--vp-c-text-1);
+}
+
+.stat-label {
+  font-size: 0.8rem;
+  color: var(--vp-c-text-3);
+  letter-spacing: 0.02em;
+}
+
+@media (max-width: 768px) {
+  .stats-container {
+    gap: 1rem;
+    padding: 1rem;
+  }
+
+  .stat-item {
+    gap: 0.375rem;
+  }
+
+  .stat-value {
+    font-size: 0.95rem;
+  }
+
+  .stat-label {
+    font-size: 0.7rem;
+  }
+}
+</style>

--- a/website/.vitepress/theme/custom.css
+++ b/website/.vitepress/theme/custom.css
@@ -1,34 +1,51 @@
 /* =====================================================
-   Claude Plugins Marketplace - Modern/Minimal Design System
+   Claude Plugins Marketplace - Terminal Craft Design System
    ===================================================== */
 
 /* -----------------------------------------------------
-   1. Design Tokens - Colors, Typography, Spacing
+   1. Design Tokens
    ----------------------------------------------------- */
 
 :root {
-  /* Brand colors - Soft indigo */
-  --vp-c-brand-1: #6366f1;
-  --vp-c-brand-2: #4f46e5;
-  --vp-c-brand-3: #818cf8;
-  --vp-c-brand-soft: rgba(99, 102, 241, 0.08);
+  /* Brand colors - Warm amber / terminal */
+  --vp-c-brand-1: #c8956c;
+  --vp-c-brand-2: #b07a52;
+  --vp-c-brand-3: #d4a574;
+  --vp-c-brand-soft: rgba(200, 149, 108, 0.1);
 
-  /* Backgrounds - Subtle */
-  --vp-c-bg: #ffffff;
-  --vp-c-bg-soft: #fafafa;
-  --vp-c-bg-mute: #f4f4f5;
-  --vp-c-bg-alt: #f9fafb;
+  /* Backgrounds - Warm */
+  --vp-c-bg: #faf8f5;
+  --vp-c-bg-soft: #f5f2ee;
+  --vp-c-bg-mute: #efeae4;
+  --vp-c-bg-alt: #f7f4f0;
 
-  /* Borders - Light */
-  --vp-c-border: #e4e4e7;
-  --vp-c-border-soft: #f4f4f5;
+  /* Borders */
+  --vp-c-border: #e0dbd4;
+  --vp-c-border-soft: #ece8e2;
 
   /* Text hierarchy */
-  --vp-c-text-1: #18181b;
-  --vp-c-text-2: #71717a;
-  --vp-c-text-3: #a1a1aa;
+  --vp-c-text-1: #1c1917;
+  --vp-c-text-2: #78716c;
+  --vp-c-text-3: #a8a29e;
 
-  /* Badge colors - Muted */
+  /* Category colors */
+  --cat-code-review: #d946ef;
+  --cat-code-review-soft: rgba(217, 70, 239, 0.08);
+  --cat-code-review-border: rgba(217, 70, 239, 0.2);
+  --cat-workflow: #3b82f6;
+  --cat-workflow-soft: rgba(59, 130, 246, 0.08);
+  --cat-workflow-border: rgba(59, 130, 246, 0.2);
+  --cat-specification: #10b981;
+  --cat-specification-soft: rgba(16, 185, 129, 0.08);
+  --cat-specification-border: rgba(16, 185, 129, 0.2);
+  --cat-utility: #f59e0b;
+  --cat-utility-soft: rgba(245, 158, 11, 0.08);
+  --cat-utility-border: rgba(245, 158, 11, 0.2);
+  --cat-infrastructure: #ef4444;
+  --cat-infrastructure-soft: rgba(239, 68, 68, 0.08);
+  --cat-infrastructure-border: rgba(239, 68, 68, 0.2);
+
+  /* Badge colors */
   --badge-skill-bg: #f0f9ff;
   --badge-skill-color: #0369a1;
   --badge-command-bg: #faf5ff;
@@ -38,7 +55,7 @@
   --badge-mcp-bg: #f0fdf4;
   --badge-mcp-color: #15803d;
 
-  /* Spacing scale */
+  /* Spacing */
   --space-1: 0.25rem;
   --space-2: 0.5rem;
   --space-3: 0.75rem;
@@ -51,6 +68,7 @@
   --space-16: 4rem;
 
   /* Typography */
+  --font-mono: 'JetBrains Mono', ui-monospace, monospace;
   --font-size-xs: 0.75rem;
   --font-size-sm: 0.875rem;
   --font-size-base: 1rem;
@@ -76,24 +94,46 @@
   --transition-slow: 0.3s ease;
 
   /* Shadows */
-  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -2px rgba(0, 0, 0, 0.05);
-  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.05), 0 4px 6px -4px rgba(0, 0, 0, 0.05);
+  --shadow-sm: 0 1px 2px 0 rgba(28, 25, 23, 0.04);
+  --shadow-md: 0 4px 6px -1px rgba(28, 25, 23, 0.06), 0 2px 4px -2px rgba(28, 25, 23, 0.04);
+  --shadow-lg: 0 10px 15px -3px rgba(28, 25, 23, 0.06), 0 4px 6px -4px rgba(28, 25, 23, 0.04);
 }
 
 /* Dark mode */
 .dark {
-  --vp-c-bg: #09090b;
-  --vp-c-bg-soft: #18181b;
-  --vp-c-bg-mute: #27272a;
-  --vp-c-bg-alt: #1c1c1f;
+  --vp-c-brand-1: #e0b687;
+  --vp-c-brand-2: #c8956c;
+  --vp-c-brand-3: #d4a574;
+  --vp-c-brand-soft: rgba(224, 182, 135, 0.1);
 
-  --vp-c-border: #27272a;
-  --vp-c-border-soft: #3f3f46;
+  --vp-c-bg: #0d0d12;
+  --vp-c-bg-soft: #16161e;
+  --vp-c-bg-mute: #1e1e28;
+  --vp-c-bg-alt: #131318;
 
-  --vp-c-text-1: #fafafa;
-  --vp-c-text-2: #a1a1aa;
-  --vp-c-text-3: #71717a;
+  --vp-c-border: #2a2a35;
+  --vp-c-border-soft: #1f1f2a;
+
+  --vp-c-text-1: #e8e4df;
+  --vp-c-text-2: #9c9890;
+  --vp-c-text-3: #6b6762;
+
+  /* Category colors - Dark mode (brighter) */
+  --cat-code-review: #e879f9;
+  --cat-code-review-soft: rgba(232, 121, 249, 0.1);
+  --cat-code-review-border: rgba(232, 121, 249, 0.25);
+  --cat-workflow: #60a5fa;
+  --cat-workflow-soft: rgba(96, 165, 250, 0.1);
+  --cat-workflow-border: rgba(96, 165, 250, 0.25);
+  --cat-specification: #34d399;
+  --cat-specification-soft: rgba(52, 211, 153, 0.1);
+  --cat-specification-border: rgba(52, 211, 153, 0.25);
+  --cat-utility: #fbbf24;
+  --cat-utility-soft: rgba(251, 191, 36, 0.1);
+  --cat-utility-border: rgba(251, 191, 36, 0.25);
+  --cat-infrastructure: #f87171;
+  --cat-infrastructure-soft: rgba(248, 113, 113, 0.1);
+  --cat-infrastructure-border: rgba(248, 113, 113, 0.25);
 
   /* Badge colors - Dark mode */
   --badge-skill-bg: rgba(14, 165, 233, 0.12);
@@ -105,7 +145,7 @@
   --badge-mcp-bg: rgba(74, 222, 128, 0.12);
   --badge-mcp-color: #86efac;
 
-  /* Shadows - Dark mode */
+  /* Shadows - Dark */
   --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
   --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -2px rgba(0, 0, 0, 0.2);
   --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.3), 0 4px 6px -4px rgba(0, 0, 0, 0.2);
@@ -115,10 +155,55 @@
    2. Global Styles
    ----------------------------------------------------- */
 
+/* Text selection */
+::selection {
+  background: rgba(200, 149, 108, 0.25);
+}
+
 /* Focus ring */
 *:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--vp-c-bg), 0 0 0 4px var(--vp-c-brand-1);
+}
+
+/* Headings get mono font */
+.vp-doc h1,
+.vp-doc h2,
+.vp-doc h3 {
+  font-family: var(--font-mono);
+}
+
+/* Nav active link */
+.VPNavBarMenuLink.active,
+.VPNavBarMenuLink:hover {
+  color: var(--vp-c-brand-1) !important;
+}
+
+/* Nav bottom border */
+.VPNav {
+  border-bottom: 1px solid var(--vp-c-border-soft) !important;
+}
+
+/* Animations */
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes blink {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+
+/* Remove VitePress home page default padding */
+.VPContent.is-home {
+  padding-bottom: 0 !important;
 }
 
 /* -----------------------------------------------------
@@ -128,7 +213,7 @@
 .plugin-card {
   position: relative;
   border: 1px solid var(--vp-c-border);
-  border-radius: 16px;
+  border-radius: 12px;
   padding: var(--space-6);
   background: var(--vp-c-bg);
   transition:
@@ -138,13 +223,26 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
+  border-left: 3px solid var(--vp-c-border);
 }
 
+/* Category border colors */
+.plugin-card[data-category="code-review"] { border-left-color: var(--cat-code-review); }
+.plugin-card[data-category="workflow"] { border-left-color: var(--cat-workflow); }
+.plugin-card[data-category="specification"] { border-left-color: var(--cat-specification); }
+.plugin-card[data-category="utility"] { border-left-color: var(--cat-utility); }
+.plugin-card[data-category="infrastructure"] { border-left-color: var(--cat-infrastructure); }
+
 .plugin-card:hover {
-  border-color: var(--vp-c-brand-3);
   box-shadow: var(--shadow-lg);
-  transform: translateY(-2px);
+  transform: translateY(-4px);
 }
+
+.plugin-card[data-category="code-review"]:hover { border-left-width: 5px; box-shadow: var(--shadow-lg), 0 0 20px var(--cat-code-review-soft); }
+.plugin-card[data-category="workflow"]:hover { border-left-width: 5px; box-shadow: var(--shadow-lg), 0 0 20px var(--cat-workflow-soft); }
+.plugin-card[data-category="specification"]:hover { border-left-width: 5px; box-shadow: var(--shadow-lg), 0 0 20px var(--cat-specification-soft); }
+.plugin-card[data-category="utility"]:hover { border-left-width: 5px; box-shadow: var(--shadow-lg), 0 0 20px var(--cat-utility-soft); }
+.plugin-card[data-category="infrastructure"]:hover { border-left-width: 5px; box-shadow: var(--shadow-lg), 0 0 20px var(--cat-infrastructure-soft); }
 
 .plugin-card-header {
   display: flex;
@@ -158,18 +256,46 @@
   gap: var(--space-3);
 }
 
+/* Category pill */
 .plugin-card-category {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  background: var(--vp-c-bg-mute);
-  border-radius: 8px;
-  color: var(--vp-c-text-2);
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-3);
+  border-radius: 100px;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+}
+
+.plugin-card-category[data-cat="code-review"] {
+  background: var(--cat-code-review-soft);
+  color: var(--cat-code-review);
+  border: 1px solid var(--cat-code-review-border);
+}
+.plugin-card-category[data-cat="workflow"] {
+  background: var(--cat-workflow-soft);
+  color: var(--cat-workflow);
+  border: 1px solid var(--cat-workflow-border);
+}
+.plugin-card-category[data-cat="specification"] {
+  background: var(--cat-specification-soft);
+  color: var(--cat-specification);
+  border: 1px solid var(--cat-specification-border);
+}
+.plugin-card-category[data-cat="utility"] {
+  background: var(--cat-utility-soft);
+  color: var(--cat-utility);
+  border: 1px solid var(--cat-utility-border);
+}
+.plugin-card-category[data-cat="infrastructure"] {
+  background: var(--cat-infrastructure-soft);
+  color: var(--cat-infrastructure);
+  border: 1px solid var(--cat-infrastructure-border);
 }
 
 .plugin-card-version {
+  font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-medium);
   color: var(--vp-c-text-3);
@@ -180,6 +306,7 @@
 }
 
 .plugin-card-title {
+  font-family: var(--font-mono);
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);
   color: var(--vp-c-text-1);
@@ -199,7 +326,62 @@
   overflow: hidden;
 }
 
-/* Feature list - minimal bullets */
+/* Install command preview */
+.install-command-preview {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: #1a1a2e;
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  overflow: hidden;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.install-command-preview:hover {
+  background: #232340;
+}
+
+.install-command-preview .prompt {
+  color: #4ade80;
+  flex-shrink: 0;
+}
+
+.install-command-preview .cmd {
+  color: #e8e4df;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+}
+
+.cmd-copy-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.4rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: none;
+  border-radius: 4px;
+  color: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all var(--transition-fast);
+}
+
+.cmd-copy-btn:hover {
+  background: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.install-command-preview:has(.cmd-copy-btn .lucide-check) .cmd-copy-btn {
+  color: #4ade80;
+}
+
+/* Feature list */
 .plugin-card-features {
   list-style: none;
   padding: 0;
@@ -222,10 +404,16 @@
   flex-shrink: 0;
   width: 5px;
   height: 5px;
-  background: var(--vp-c-brand-1);
   border-radius: 50%;
   margin-top: 7px;
 }
+
+/* Feature bullet colors by category */
+.plugin-card[data-category="code-review"] .feature-bullet { background: var(--cat-code-review); }
+.plugin-card[data-category="workflow"] .feature-bullet { background: var(--cat-workflow); }
+.plugin-card[data-category="specification"] .feature-bullet { background: var(--cat-specification); }
+.plugin-card[data-category="utility"] .feature-bullet { background: var(--cat-utility); }
+.plugin-card[data-category="infrastructure"] .feature-bullet { background: var(--cat-infrastructure); }
 
 /* Badges */
 .plugin-card-badges {
@@ -246,11 +434,11 @@
   padding: var(--space-1) var(--space-2);
   border-radius: 6px;
   letter-spacing: var(--letter-spacing-wide);
-  transition: filter var(--transition-fast);
+  transition: transform var(--transition-fast);
 }
 
 .badge:hover {
-  filter: brightness(0.95);
+  transform: scale(1.05);
 }
 
 .badge-skill {
@@ -273,16 +461,26 @@
   color: var(--badge-mcp-color);
 }
 
-.badge-category {
-  background: var(--vp-c-bg-mute);
-  color: var(--vp-c-text-2);
-}
-
 /* Card actions */
 .plugin-card-actions {
   display: flex;
   gap: var(--space-2);
-  padding-top: var(--space-4);
+  padding-top: var(--space-3);
+}
+
+.detail-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--vp-c-text-3);
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+
+.detail-link:hover {
+  color: var(--vp-c-brand-1);
 }
 
 /* -----------------------------------------------------
@@ -308,14 +506,23 @@
   transform: scale(0.98);
 }
 
+/* Terminal-style install button */
 .btn-primary {
   flex: 1;
-  background: var(--vp-c-brand-1);
-  color: white;
+  background: #1a1a2e;
+  color: #4ade80;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
 }
 
 .btn-primary:hover {
-  background: var(--vp-c-brand-2);
+  background: #232340;
+  box-shadow: 0 0 12px rgba(74, 222, 128, 0.1);
+}
+
+.btn-primary .dollar-sign {
+  color: #d4a574;
+  margin-right: 0.25rem;
 }
 
 .btn-secondary {
@@ -339,22 +546,16 @@
   color: var(--vp-c-text-1);
 }
 
-.btn-outline {
-  background: transparent;
-  color: var(--vp-c-brand-1);
-  border: 1px solid var(--vp-c-brand-1);
-}
-
-.btn-outline:hover {
-  background: var(--vp-c-brand-1);
-  color: white;
-}
-
 /* Copy success state */
 .copy-success {
-  color: #16a34a;
+  color: #4ade80;
   font-size: var(--font-size-xs);
   margin-left: var(--space-2);
+}
+
+.btn-sm {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-xs);
 }
 
 /* -----------------------------------------------------
@@ -381,7 +582,7 @@
   position: relative;
   flex: 1;
   min-width: 280px;
-  max-width: 400px;
+  max-width: 480px;
 }
 
 .search-icon {
@@ -397,6 +598,8 @@
   width: 100%;
   padding: var(--space-3) var(--space-4);
   padding-left: calc(var(--space-4) * 2 + 18px);
+  padding-right: 3.5rem;
+  font-family: var(--font-mono);
   font-size: var(--font-size-sm);
   border: 1px solid var(--vp-c-border);
   border-radius: 10px;
@@ -415,12 +618,88 @@
 
 .search-input::placeholder {
   color: var(--vp-c-text-3);
+  font-family: var(--font-mono);
+}
+
+.search-kbd {
+  position: absolute;
+  right: var(--space-3);
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 0.125rem 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--vp-c-text-3);
+  background: var(--vp-c-bg-mute);
+  border: 1px solid var(--vp-c-border);
+  border-radius: 4px;
+  pointer-events: none;
+}
+
+/* Category filter pills */
+.category-pills {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.category-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  border-radius: 100px;
+  border: 1px solid var(--vp-c-border);
+  background: transparent;
+  color: var(--vp-c-text-2);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  white-space: nowrap;
+}
+
+.category-pill:hover {
+  border-color: var(--vp-c-text-3);
+}
+
+.category-pill.active {
+  color: var(--vp-c-bg);
+  border-color: transparent;
+}
+
+.category-pill[data-cat="all"].active {
+  background: var(--vp-c-text-1);
+  color: var(--vp-c-bg);
+}
+
+.category-pill[data-cat="code-review"].active {
+  background: var(--cat-code-review);
+}
+.category-pill[data-cat="workflow"].active {
+  background: var(--cat-workflow);
+}
+.category-pill[data-cat="specification"].active {
+  background: var(--cat-specification);
+}
+.category-pill[data-cat="utility"].active {
+  background: var(--cat-utility);
+}
+.category-pill[data-cat="infrastructure"].active {
+  background: var(--cat-infrastructure);
+}
+
+.pill-count {
+  font-size: 0.65rem;
+  opacity: 0.8;
 }
 
 /* Filter group */
 .filter-group {
   display: flex;
   gap: var(--space-3);
+  align-items: center;
 }
 
 .filter-select {
@@ -445,37 +724,6 @@
   border-color: var(--vp-c-brand-1);
 }
 
-/* Legacy filter styles (fallback) */
-.plugin-list-filters {
-  display: flex;
-  gap: var(--space-4);
-  margin-bottom: var(--space-6);
-  flex-wrap: wrap;
-  align-items: center;
-}
-
-.plugin-list-filters select,
-.plugin-list-filters input {
-  padding: var(--space-3) var(--space-4);
-  border: 1px solid var(--vp-c-border);
-  border-radius: 10px;
-  background: var(--vp-c-bg);
-  color: var(--vp-c-text-1);
-  font-size: var(--font-size-sm);
-  transition: border-color var(--transition-fast);
-}
-
-.plugin-list-filters input {
-  flex: 1;
-  min-width: 200px;
-}
-
-.plugin-list-filters input:focus,
-.plugin-list-filters select:focus {
-  outline: none;
-  border-color: var(--vp-c-brand-1);
-}
-
 /* Results meta */
 .plugin-results-meta {
   display: flex;
@@ -487,12 +735,14 @@
 }
 
 .plugin-count {
+  font-family: var(--font-mono);
   font-size: var(--font-size-sm);
   color: var(--vp-c-text-2);
   margin-bottom: var(--space-4);
 }
 
 .clear-filters {
+  font-family: var(--font-mono);
   font-size: var(--font-size-sm);
   color: var(--vp-c-brand-1);
   background: none;
@@ -513,6 +763,20 @@
   grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
   gap: var(--space-6);
 }
+
+/* Card entrance animation */
+.plugin-grid .plugin-card,
+.plugin-list-view .plugin-card {
+  animation: fadeInUp 0.4s ease both;
+}
+
+.plugin-grid .plugin-card:nth-child(1) { animation-delay: 0ms; }
+.plugin-grid .plugin-card:nth-child(2) { animation-delay: 50ms; }
+.plugin-grid .plugin-card:nth-child(3) { animation-delay: 100ms; }
+.plugin-grid .plugin-card:nth-child(4) { animation-delay: 150ms; }
+.plugin-grid .plugin-card:nth-child(5) { animation-delay: 200ms; }
+.plugin-grid .plugin-card:nth-child(6) { animation-delay: 250ms; }
+.plugin-grid .plugin-card:nth-child(n+7) { animation-delay: 300ms; }
 
 /* Plugin list view */
 .plugin-list-view {
@@ -561,14 +825,15 @@
   align-items: flex-start;
   padding: var(--space-4);
   gap: var(--space-4);
-  border-radius: 12px;
+  border-radius: 10px;
+  border-left-width: 3px;
 }
 
 .plugin-card-list:hover {
   transform: none;
+  border-left-width: 5px;
 }
 
-/* List view - Icon */
 .plugin-list-icon {
   display: flex;
   align-items: center;
@@ -581,7 +846,6 @@
   flex-shrink: 0;
 }
 
-/* List view - Main content */
 .plugin-list-main {
   flex: 1;
   min-width: 0;
@@ -610,7 +874,6 @@
   margin: 0;
 }
 
-/* List view - Right section */
 .plugin-list-right {
   display: flex;
   align-items: center;
@@ -630,12 +893,6 @@
   gap: var(--space-2);
 }
 
-/* Small button variant */
-.btn-sm {
-  padding: var(--space-2) var(--space-3);
-  font-size: var(--font-size-xs);
-}
-
 .plugin-card-list .btn-primary {
   flex: none;
 }
@@ -653,10 +910,11 @@
 
 .empty-state svg {
   margin-bottom: var(--space-4);
-  opacity: 0.5;
+  opacity: 0.4;
 }
 
 .empty-state p {
+  font-family: var(--font-mono);
   font-size: var(--font-size-base);
   margin: 0;
 }
@@ -666,9 +924,19 @@
    ----------------------------------------------------- */
 
 .home-features {
-  padding: var(--space-12) 0 var(--space-16);
-  max-width: 1152px;
+  padding: var(--space-8) 0 var(--space-12);
+  max-width: 1200px;
   margin: 0 auto;
+}
+
+.features-section-title {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+  color: var(--vp-c-text-1);
+  text-align: center;
+  margin: 0 0 var(--space-8) 0;
+  letter-spacing: var(--letter-spacing-tight);
 }
 
 .features-container {
@@ -681,11 +949,14 @@
 .feature-card {
   background: var(--vp-c-bg);
   border: 1px solid var(--vp-c-border-soft);
-  border-radius: 16px;
+  border-radius: 12px;
   padding: var(--space-8);
   transition:
     border-color var(--transition-normal),
-    box-shadow var(--transition-normal);
+    box-shadow var(--transition-normal),
+    background var(--transition-normal);
+  text-decoration: none;
+  display: block;
 }
 
 .feature-card:hover {
@@ -697,27 +968,96 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 48px;
-  height: 48px;
-  background: linear-gradient(135deg, var(--vp-c-brand-soft) 0%, transparent 100%);
-  border-radius: 12px;
-  color: var(--vp-c-brand-1);
+  width: 56px;
+  height: 56px;
+  border-radius: 14px;
   margin-bottom: var(--space-5);
 }
 
+.feature-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-2);
+}
+
 .feature-title {
+  font-family: var(--font-mono);
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-semibold);
   color: var(--vp-c-text-1);
-  margin: 0 0 var(--space-2) 0;
+  margin: 0;
   letter-spacing: var(--letter-spacing-tight);
+}
+
+.feature-count {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--vp-c-text-3);
 }
 
 .feature-details {
   font-size: var(--font-size-sm);
   color: var(--vp-c-text-2);
   line-height: var(--line-height-relaxed);
-  margin: 0;
+  margin: 0 0 var(--space-4) 0;
+}
+
+.feature-link {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.feature-link:hover {
+  text-decoration: underline;
+}
+
+/* Category-specific feature card hover tints */
+.feature-card[data-cat="code-review"]:hover { background: var(--cat-code-review-soft); }
+.feature-card[data-cat="workflow"]:hover { background: var(--cat-workflow-soft); }
+.feature-card[data-cat="specification"]:hover { background: var(--cat-specification-soft); }
+.feature-card[data-cat="utility"]:hover { background: var(--cat-utility-soft); }
+.feature-card[data-cat="infrastructure"]:hover { background: var(--cat-infrastructure-soft); }
+
+/* Feature icon backgrounds by category */
+.feature-icon[data-cat="code-review"] {
+  background: var(--cat-code-review-soft);
+  border: 1px solid var(--cat-code-review-border);
+  color: var(--cat-code-review);
+}
+.feature-icon[data-cat="workflow"] {
+  background: var(--cat-workflow-soft);
+  border: 1px solid var(--cat-workflow-border);
+  color: var(--cat-workflow);
+}
+.feature-icon[data-cat="specification"] {
+  background: var(--cat-specification-soft);
+  border: 1px solid var(--cat-specification-border);
+  color: var(--cat-specification);
+}
+.feature-icon[data-cat="utility"] {
+  background: var(--cat-utility-soft);
+  border: 1px solid var(--cat-utility-border);
+  color: var(--cat-utility);
+}
+.feature-icon[data-cat="infrastructure"] {
+  background: var(--cat-infrastructure-soft);
+  border: 1px solid var(--cat-infrastructure-border);
+  color: var(--cat-infrastructure);
+}
+
+/* Legacy filter styles (fallback) */
+.plugin-list-filters {
+  display: flex;
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+  flex-wrap: wrap;
+  align-items: center;
 }
 
 /* -----------------------------------------------------
@@ -725,13 +1065,14 @@
    ----------------------------------------------------- */
 
 .quick-start-section {
-  padding: var(--space-12) var(--space-6);
+  padding: var(--space-8) var(--space-6) var(--space-12);
   text-align: center;
   max-width: 800px;
   margin: 0 auto;
 }
 
 .quick-start-section h2 {
+  font-family: var(--font-mono);
   font-size: var(--font-size-2xl);
   font-weight: var(--font-weight-semibold);
   margin-bottom: var(--space-8);
@@ -761,6 +1102,7 @@
   background: var(--vp-c-brand-soft);
   color: var(--vp-c-brand-1);
   border-radius: 50%;
+  font-family: var(--font-mono);
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-semibold);
 }
@@ -771,26 +1113,7 @@
 }
 
 /* -----------------------------------------------------
-   8. Hero Customization
-   ----------------------------------------------------- */
-
-.VPHero .name {
-  background: linear-gradient(135deg, var(--vp-c-text-1) 0%, var(--vp-c-brand-1) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-.VPHero .VPButton.brand {
-  border-radius: 10px;
-}
-
-.VPHero .VPButton.alt {
-  border-radius: 10px;
-}
-
-/* -----------------------------------------------------
-   9. Responsive
+   8. Responsive
    ----------------------------------------------------- */
 
 @media (max-width: 768px) {
@@ -801,6 +1124,13 @@
 
   .search-container {
     max-width: none;
+  }
+
+  .category-pills {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    padding-bottom: var(--space-2);
+    -webkit-overflow-scrolling: touch;
   }
 
   .filter-group {
@@ -821,7 +1151,6 @@
     grid-template-columns: 1fr;
   }
 
-  /* List view on mobile - stack vertically */
   .plugin-card-list {
     flex-direction: column;
     align-items: stretch;
@@ -837,14 +1166,6 @@
     justify-content: space-between;
   }
 
-  .plugin-list-filters {
-    flex-direction: column;
-  }
-
-  .plugin-list-filters input {
-    width: 100%;
-  }
-
   .features-container {
     grid-template-columns: 1fr;
   }
@@ -853,5 +1174,13 @@
     flex-direction: column;
     align-items: center;
     gap: var(--space-4);
+  }
+
+  .plugin-list-filters {
+    flex-direction: column;
+  }
+
+  .plugin-list-filters input {
+    width: 100%;
   }
 }

--- a/website/.vitepress/theme/index.ts
+++ b/website/.vitepress/theme/index.ts
@@ -2,6 +2,9 @@ import DefaultTheme from 'vitepress/theme'
 import PluginCard from './components/PluginCard.vue'
 import PluginList from './components/PluginList.vue'
 import HomeFeatures from './components/HomeFeatures.vue'
+import HeroSection from './components/HeroSection.vue'
+import StatsBar from './components/StatsBar.vue'
+import InstallBanner from './components/InstallBanner.vue'
 import './custom.css'
 
 export default {
@@ -10,5 +13,8 @@ export default {
     app.component('PluginCard', PluginCard)
     app.component('PluginList', PluginList)
     app.component('HomeFeatures', HomeFeatures)
+    app.component('HeroSection', HeroSection)
+    app.component('StatsBar', StatsBar)
+    app.component('InstallBanner', InstallBanner)
   }
 }

--- a/website/data/plugins.json
+++ b/website/data/plugins.json
@@ -6,6 +6,51 @@
   },
   "plugins": [
     {
+      "id": "agent-team-plugin",
+      "name": "agent-team-plugin",
+      "version": "2.0.0",
+      "description": "Agent team management - create, expand, and cleanup teams for worktree sessions",
+      "author": "Stefan Cho",
+      "category": "utility",
+      "components": {
+        "skills": [
+          "create-team"
+        ],
+        "commands": [
+          "cleanup-team",
+          "expand-team"
+        ],
+        "hooks": false,
+        "mcpServers": []
+      },
+      "features": [],
+      "installCommand": "/plugin install agent-team-plugin@devstefancho-claude-plugins",
+      "uninstallCommand": "/plugin uninstall agent-team-plugin@devstefancho-claude-plugins",
+      "readmePath": "agent-team-plugin/README.md",
+      "hasReadme": true
+    },
+    {
+      "id": "brain-storm-plugin",
+      "name": "brain-storm-plugin",
+      "version": "1.0.0",
+      "description": "Brainstorm future features and improvements with wireframes and implementation detection",
+      "author": "Stefan Cho",
+      "category": "utility",
+      "components": {
+        "skills": [
+          "brain-storm"
+        ],
+        "commands": [],
+        "hooks": false,
+        "mcpServers": []
+      },
+      "features": [],
+      "installCommand": "/plugin install brain-storm-plugin@devstefancho-claude-plugins",
+      "uninstallCommand": "/plugin uninstall brain-storm-plugin@devstefancho-claude-plugins",
+      "readmePath": "brain-storm-plugin/README.md",
+      "hasReadme": true
+    },
+    {
       "id": "code-quality-plugin",
       "name": "code-quality-plugin",
       "version": "1.0.0",
@@ -79,6 +124,27 @@
       "hasReadme": true
     },
     {
+      "id": "computer-use-plugin",
+      "name": "computer-use-plugin",
+      "version": "1.0.0",
+      "description": "Computer Use MCP app testing with scenario execution and feedback reporting",
+      "author": "Stefan Cho",
+      "category": "utility",
+      "components": {
+        "skills": [
+          "computer-use-test"
+        ],
+        "commands": [],
+        "hooks": false,
+        "mcpServers": []
+      },
+      "features": [],
+      "installCommand": "/plugin install computer-use-plugin@devstefancho-claude-plugins",
+      "uninstallCommand": "/plugin uninstall computer-use-plugin@devstefancho-claude-plugins",
+      "readmePath": "computer-use-plugin/README.md",
+      "hasReadme": true
+    },
+    {
       "id": "frontend-plugin",
       "name": "frontend-plugin",
       "version": "1.0.0",
@@ -126,29 +192,72 @@
       "hasReadme": true
     },
     {
-      "id": "git-worktree-plugin",
-      "name": "git-worktree-plugin",
-      "version": "1.1.0",
-      "description": "Manage git worktrees for parallel branch work. Proactively suggests worktree creation when working on PRs or new features",
+      "id": "hermes-gateway-plugin",
+      "name": "hermes",
+      "version": "1.0.0",
+      "description": "Interact with Hermes Agent via local or SSH-tunneled connection",
       "author": "Stefan Cho",
-      "category": "workflow",
+      "category": "utility",
       "components": {
         "skills": [
-          "git-worktree"
+          "hermes-runtime"
         ],
         "commands": [
-          "bare-setup"
+          "chat",
+          "jobs",
+          "run",
+          "setup",
+          "status"
         ],
         "hooks": false,
         "mcpServers": []
       },
-      "features": [
-        "Easy Creation - Creates worktrees with proper branch naming conventions",
-        "Cleanup Management - Lists and removes worktrees safely"
-      ],
-      "installCommand": "/plugin install git-worktree-plugin@devstefancho-claude-plugins",
-      "uninstallCommand": "/plugin uninstall git-worktree-plugin@devstefancho-claude-plugins",
-      "readmePath": "git-worktree-plugin/README.md",
+      "features": [],
+      "installCommand": "/plugin install hermes-gateway-plugin@devstefancho-claude-plugins",
+      "uninstallCommand": "/plugin uninstall hermes-gateway-plugin@devstefancho-claude-plugins",
+      "readmePath": "hermes-gateway-plugin/README.md",
+      "hasReadme": false
+    },
+    {
+      "id": "implement-with-test-plugin",
+      "name": "implement-with-test-plugin",
+      "version": "1.0.0",
+      "description": "Implement code with tests from specs or direct requests",
+      "author": "Stefan Cho",
+      "category": "utility",
+      "components": {
+        "skills": [
+          "implement-with-test"
+        ],
+        "commands": [],
+        "hooks": false,
+        "mcpServers": []
+      },
+      "features": [],
+      "installCommand": "/plugin install implement-with-test-plugin@devstefancho-claude-plugins",
+      "uninstallCommand": "/plugin uninstall implement-with-test-plugin@devstefancho-claude-plugins",
+      "readmePath": "implement-with-test-plugin/README.md",
+      "hasReadme": true
+    },
+    {
+      "id": "local-test-plugin",
+      "name": "local-test-plugin",
+      "version": "1.0.0",
+      "description": "Symlink-based local plugin testing for development workflow",
+      "author": "Stefan Cho",
+      "category": "utility",
+      "components": {
+        "skills": [
+          "local-test"
+        ],
+        "commands": [],
+        "hooks": false,
+        "mcpServers": []
+      },
+      "features": [],
+      "installCommand": "/plugin install local-test-plugin@devstefancho-claude-plugins",
+      "uninstallCommand": "/plugin uninstall local-test-plugin@devstefancho-claude-plugins",
+      "readmePath": "local-test-plugin/README.md",
       "hasReadme": true
     },
     {
@@ -391,37 +500,25 @@
       "hasReadme": true
     },
     {
-      "id": "hermes-gateway-plugin",
-      "name": "hermes",
+      "id": "writing-specs-plugin",
+      "name": "writing-specs-plugin",
       "version": "1.0.0",
-      "description": "Interact with Hermes Agent via local or SSH-tunneled connection",
+      "description": "Spec-driven development with search, conflict detection, and reporting",
       "author": "Stefan Cho",
-      "category": "integration",
+      "category": "utility",
       "components": {
         "skills": [
-          "hermes-runtime"
+          "writing-specs"
         ],
-        "commands": [
-          "setup",
-          "chat",
-          "run",
-          "status",
-          "jobs"
-        ],
+        "commands": [],
         "hooks": false,
         "mcpServers": []
       },
-      "features": [
-        "Chat with Hermes Agent (streaming supported)",
-        "Async task execution with SSE event streaming",
-        "SSH tunnel auto-management for remote Hermes",
-        "Connection mode: auto/local/ssh",
-        "Cron job management"
-      ],
-      "installCommand": "/plugin install hermes@devstefancho-claude-plugins",
-      "uninstallCommand": "/plugin uninstall hermes@devstefancho-claude-plugins",
-      "readmePath": "hermes-gateway-plugin/README.md",
-      "hasReadme": false
+      "features": [],
+      "installCommand": "/plugin install writing-specs-plugin@devstefancho-claude-plugins",
+      "uninstallCommand": "/plugin uninstall writing-specs-plugin@devstefancho-claude-plugins",
+      "readmePath": "writing-specs-plugin/README.md",
+      "hasReadme": true
     }
   ],
   "categories": [

--- a/website/data/plugins.json
+++ b/website/data/plugins.json
@@ -213,8 +213,8 @@
         "mcpServers": []
       },
       "features": [],
-      "installCommand": "/plugin install hermes-gateway-plugin@devstefancho-claude-plugins",
-      "uninstallCommand": "/plugin uninstall hermes-gateway-plugin@devstefancho-claude-plugins",
+      "installCommand": "/plugin install hermes@devstefancho-claude-plugins",
+      "uninstallCommand": "/plugin uninstall hermes@devstefancho-claude-plugins",
       "readmePath": "hermes-gateway-plugin/README.md",
       "hasReadme": false
     },

--- a/website/en/index.md
+++ b/website/en/index.md
@@ -1,18 +1,9 @@
 ---
-layout: home
-hero:
-  name: Claude Plugins
-  text: Claude Code Plugin Marketplace
-  tagline: Extend Claude Code with Skills, Commands, Hooks, and MCP Servers
-  actions:
-    - theme: brand
-      text: Browse Plugins
-      link: /en/plugins/
-    - theme: alt
-      text: Get Started
-      link: /en/guide/getting-started
+layout: page
 ---
 
+<HeroSection lang="en" />
+<StatsBar lang="en" />
 <HomeFeatures lang="en" />
 
 <div class="quick-start-section">

--- a/website/en/plugins/index.md
+++ b/website/en/plugins/index.md
@@ -2,14 +2,4 @@
 
 Discover plugins that extend Claude Code capabilities.
 
-## Register Marketplace
-
-Before installing plugins, register the marketplace first:
-
-```bash
-/plugin marketplace add devstefancho/claude-plugins
-```
-
----
-
 <PluginList lang="en" />

--- a/website/index.md
+++ b/website/index.md
@@ -1,35 +1,14 @@
 ---
-layout: home
-hero:
-  name: Claude Plugins
-  text: Claude Code Plugin Marketplace
-  tagline: Extend Claude Code with Skills, Commands, Hooks, and MCP Servers
-  actions:
-    - theme: brand
-      text: Browse Plugins
-      link: /plugins/
-    - theme: alt
-      text: Get Started
-      link: /guide/getting-started
+layout: page
+head:
+  - - meta
+    - http-equiv: refresh
+      content: "0;url=/plugins/"
 ---
 
-<HomeFeatures lang="en" />
-
-<div style="padding: 2rem; text-align: center;">
-
-## Quick Start
-
-```bash
-# Using Claude Code CLI
-/plugin marketplace add devstefancho/claude-plugins
-/plugin install code-style-plugin@devstefancho-claude-plugins
-```
-
-```bash
-# Or using npx (from any terminal)
-npx skills add devstefancho/claude-plugins
-```
-
-[View All Plugins →](/plugins/)
-
-</div>
+<script setup>
+import { onMounted } from 'vue'
+import { useRouter } from 'vitepress'
+const router = useRouter()
+onMounted(() => { router.go('/plugins/') })
+</script>

--- a/website/ko/index.md
+++ b/website/ko/index.md
@@ -1,14 +1,41 @@
 ---
 layout: page
-head:
-  - - meta
-    - http-equiv: refresh
-      content: "0;url=/ko/plugins/"
 ---
 
-<script setup>
-import { onMounted } from 'vue'
-import { useRouter } from 'vitepress'
-const router = useRouter()
-onMounted(() => { router.go('/ko/plugins/') })
-</script>
+<HeroSection lang="ko" />
+<StatsBar lang="ko" />
+<HomeFeatures lang="ko" />
+
+<div class="quick-start-section">
+
+## 빠른 시작
+
+<div class="quick-start-steps">
+  <div class="step">
+    <span class="step-number">1</span>
+    <span class="step-text">마켓플레이스 등록</span>
+  </div>
+  <div class="step">
+    <span class="step-number">2</span>
+    <span class="step-text">플러그인 설치</span>
+  </div>
+  <div class="step">
+    <span class="step-number">3</span>
+    <span class="step-text">Claude Code 재시작</span>
+  </div>
+</div>
+
+```bash
+# Claude Code CLI 사용
+/plugin marketplace add devstefancho/claude-plugins
+/plugin install code-style-plugin@devstefancho-claude-plugins
+```
+
+```bash
+# 또는 npx 사용 (아무 터미널에서)
+npx skills add devstefancho/claude-plugins
+```
+
+[전체 플러그인 보기 →](/ko/plugins/)
+
+</div>

--- a/website/ko/index.md
+++ b/website/ko/index.md
@@ -1,50 +1,14 @@
 ---
-layout: home
-hero:
-  name: Claude Plugins
-  text: Claude Code 플러그인 마켓플레이스
-  tagline: Skills, Commands, Hooks, MCP Servers를 통해 Claude Code를 확장하세요
-  actions:
-    - theme: brand
-      text: 플러그인 둘러보기
-      link: /ko/plugins/
-    - theme: alt
-      text: 시작하기
-      link: /ko/guide/getting-started
+layout: page
+head:
+  - - meta
+    - http-equiv: refresh
+      content: "0;url=/ko/plugins/"
 ---
 
-<HomeFeatures lang="ko" />
-
-<div class="quick-start-section">
-
-## 빠른 시작
-
-<div class="quick-start-steps">
-  <div class="step">
-    <span class="step-number">1</span>
-    <span class="step-text">마켓플레이스 등록</span>
-  </div>
-  <div class="step">
-    <span class="step-number">2</span>
-    <span class="step-text">플러그인 설치</span>
-  </div>
-  <div class="step">
-    <span class="step-number">3</span>
-    <span class="step-text">Claude Code 재시작</span>
-  </div>
-</div>
-
-```bash
-# Claude Code CLI 사용
-/plugin marketplace add devstefancho/claude-plugins
-/plugin install code-style-plugin@devstefancho-claude-plugins
-```
-
-```bash
-# 또는 npx 사용 (일반 터미널에서)
-npx skills add devstefancho/claude-plugins
-```
-
-[모든 플러그인 보기 →](/ko/plugins/)
-
-</div>
+<script setup>
+import { onMounted } from 'vue'
+import { useRouter } from 'vitepress'
+const router = useRouter()
+onMounted(() => { router.go('/ko/plugins/') })
+</script>

--- a/website/ko/plugins/index.md
+++ b/website/ko/plugins/index.md
@@ -2,14 +2,4 @@
 
 Claude Code를 확장하는 다양한 플러그인을 찾아보세요.
 
-## 마켓플레이스 등록
-
-플러그인을 설치하기 전에 마켓플레이스를 먼저 등록해야 합니다:
-
-```bash
-/plugin marketplace add devstefancho/claude-plugins
-```
-
----
-
 <PluginList lang="ko" />

--- a/website/plugins/index.md
+++ b/website/plugins/index.md
@@ -2,14 +2,4 @@
 
 Discover plugins that extend Claude Code capabilities.
 
-## Register Marketplace
-
-Before installing plugins, register the marketplace first:
-
-```bash
-/plugin marketplace add devstefancho/claude-plugins
-```
-
----
-
 <PluginList lang="en" />


### PR DESCRIPTION
## Summary
- Plugin Store 웹사이트 UI/UX를 Terminal Craft 테마로 전면 리디자인
- URL 동기화, 홈 리디렉트, 검색 UX 개선
- 플러그인 install 명령어에서 디렉토리명 대신 plugin name을 사용하도록 버그 수정

## Changes
- `website/` - VitePress 기반 플러그인 스토어 UI 전면 개편
- `scripts/generate-plugin-data.js` - install 명령어 생성 시 `metadata.name` 사용
- `website/data/plugins.json` - 재생성된 플러그인 데이터

## Test plan
- [x] `npm run dev` 로 로컬에서 웹사이트 확인
- [x] 플러그인 카드의 install 명령어가 올바른 플러그인 이름인지 확인
- [x] `/plugin install hermes@devstefancho-claude-plugins` 로 설치 가능한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)