### PR TITLE
docs: add root README and standardize plugin READMEs in English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,107 @@
+# Claude Code Plugins Marketplace
+
+A collection of reusable [Claude Code](https://claude.ai/code) plugins — slash commands, agent skills, subagents, hooks, and MCP server integrations.
+
+## Quick Start
+
+```bash
+# 1. Add this marketplace
+/plugin marketplace add devstefancho/claude-plugins
+
+# 2. Install a plugin
+/plugin install <plugin-name>@devstefancho-claude-plugins
+
+# 3. Restart Claude Code to activate
+```
+
+## Available Plugins
+
+### Code Quality
+
+| Plugin | Description |
+|--------|-------------|
+| [code-style-plugin](./code-style-plugin) | Code review based on SRP, DRY, Simplicity First, YAGNI, and Type Safety |
+| [code-quality-plugin](./code-quality-plugin) | Code quality review focusing on DRY, KISS, and Clean Code principles |
+| [frontend-plugin](./frontend-plugin) | React/Next.js component design review |
+
+### Spec-Driven Development
+
+| Plugin | Description |
+|--------|-------------|
+| [writing-specs-plugin](./writing-specs-plugin) | Spec writing with conflict detection and reporting |
+| [simple-sdd-plugin](./simple-sdd-plugin) | SDD workflow: spec → plan → tasks → implement |
+| [implement-with-test-plugin](./implement-with-test-plugin) | Implement code with tests from specs or direct requests |
+| [brain-storm-plugin](./brain-storm-plugin) | Brainstorm features and improvements with wireframes |
+
+### Git & Workflow
+
+| Plugin | Description |
+|--------|-------------|
+| [git-worktree-plugin](./git-worktree-plugin) | Manage git worktrees for parallel branch work |
+| [git-commit-plugin](./git-commit-plugin) | Auto-generate conventional commit messages |
+| [smart-commit-plugin](./smart-commit-plugin) | Split uncommitted changes into logical commits |
+| [pr-create-plugin](./pr-create-plugin) | Create GitHub PRs with auto-generated descriptions |
+| [test-commit-push-pr-clean-plugin](./test-commit-push-pr-clean-plugin) | Automate lint, test, commit, push, PR, and worktree cleanup |
+
+### Testing & Reporting
+
+| Plugin | Description |
+|--------|-------------|
+| [computer-use-plugin](./computer-use-plugin) | App testing via Computer Use MCP with feedback reports |
+| [session-reporter-plugin](./session-reporter-plugin) | Generate HTML reports for work sessions |
+| [worktrace-plugin](./worktrace-plugin) | Extract work history and generate daily summaries |
+
+### Agent & Automation
+
+| Plugin | Description |
+|--------|-------------|
+| [agent-team-plugin](./agent-team-plugin) | Create and manage agent teams for worktree sessions |
+| [hermes-gateway-plugin](./hermes-gateway-plugin) | Interact with Hermes Agent via local or SSH connection |
+| [stop-notification-plugin](./stop-notification-plugin) | macOS TTS notification when Claude stops or needs attention |
+
+### Tooling
+
+| Plugin | Description |
+|--------|-------------|
+| [scaffold-claude-feature](./scaffold-claude-feature) | Generate Claude Code features with proper structure |
+| [common-mcp-plugin](./common-mcp-plugin) | Common MCP servers for shared tools and integrations |
+| [local-test-plugin](./local-test-plugin) | Symlink-based local plugin testing |
+
+### Deprecated
+
+| Plugin | Description |
+|--------|-------------|
+| [spec-manager-plugin](./spec-manager-plugin) | Replaced by `writing-specs-plugin` |
+
+## Plugin Structure
+
+Each plugin follows this layout:
+
+```
+plugin-name/
+├── .claude-plugin/
+│   └── plugin.json         # Plugin metadata (required)
+├── commands/               # Slash commands
+├── skills/                 # Agent skills
+├── agents/                 # Subagents
+├── hooks/                  # Event handlers
+├── .mcp.json               # MCP servers
+└── README.md
+```
+
+## Local Development
+
+```bash
+# Clone and add as local marketplace
+git clone https://github.com/devstefancho/claude-plugins.git
+cd claude-plugins
+claude
+
+# Inside Claude Code
+/plugin marketplace add .
+/plugin install <plugin-name>@devstefancho-claude-plugins
+```
+
+## License
+
+MIT

--- a/agent-team-plugin/README.md
+++ b/agent-team-plugin/README.md
@@ -1,97 +1,89 @@
-# agent-team-plugin
+# Agent Team Plugin
 
-워크트리 세션에서 agent team을 생성, 확장, 정리하는 플러그인.
+Create, expand, and manage agent teams for worktree sessions. Orchestrates multi-agent collaboration with a task-driven workflow.
 
-## 설치
+## Installation
 
 ```bash
 /plugin marketplace add .
 /plugin install agent-team-plugin@devstefancho-claude-plugins
 ```
 
-## 커맨드 목록
+## Prerequisites
+
+- Must start with `claude -w` (worktree session)
+- `writing-specs-plugin` recommended for planner's spec writing (optional)
+
+## Commands
 
 | Command | Description |
 |---------|-------------|
-| `create team` (스킬) | planner + implementer 기본 팀 생성 |
-| `/expand-team` | 기존 팀에 새 팀원 추가 |
-| `/cleanup-team` | 팀원 종료 및 팀 정리 |
+| `create team` (skill) | Create a default team with planner + implementer |
+| `/expand-team` | Add specialized roles to existing team |
+| `/cleanup-team` | Terminate members and clean up team |
 
-## 팀 생성
+## Trigger Keywords
 
-워크트리 세션에서 다음과 같이 트리거:
+- "create team", "agent team"
 
-```
-팀 생성해줘
-create team
-agent team 만들어줘
-```
-
-### 기본 팀 구성
+## Default Team Structure
 
 | Member | Role |
 |--------|------|
-| team-lead | 오케스트레이션, 작업 할당 |
-| planner | 브레인스톰, spec 작성 |
-| implementer | 코드 구현, 테스트 작성 |
+| team-lead | Orchestration, task assignment |
+| planner | Brainstorming, spec writing |
+| implementer | Code implementation, test writing |
 
-### 작업 흐름
+### Workflow
 
 ```
 Goal → planner(spec) → TaskCreate → team-lead review → implementer(code) → Done
 ```
 
-## 팀 확장 (Expand)
-
-기존 팀에 전문 역할 팀원을 추가:
+## Expanding the Team
 
 ```
-/expand-team           # 역할 카탈로그에서 선택 (추천 포함)
-/expand-team tester    # 직접 역할 지정
+/expand-team           # Show role catalog with recommendations
+/expand-team tester    # Add a specific role directly
 ```
 
-### 역할 카탈로그
+### Available Roles
 
 | Role | Description | Best For |
 |------|-------------|----------|
-| **tester** | 테스트 작성, 커버리지 분석 | 구현 완료 후 품질 검증 |
-| **reviewer** | 코드 리뷰, 보안/성능 체크 | PR 전 코드 품질 게이트 |
-| **researcher** | 코드베이스 탐색, 기술 조사 | 새 기술 도입, 레거시 분석 |
-| **architect** | 시스템 설계, API 설계 | 대규모 기능, 리팩토링 |
-| **devops** | CI/CD, Docker, IaC | 인프라 작업, 파이프라인 |
-| **ui-designer** | UI 컴포넌트, 디자인 시스템 | 프론트엔드 중심 작업 |
-| **security-auditor** | 보안 취약점, CVE 검사 | 보안 감사, 릴리스 전 점검 |
-| **custom** | 사용자 정의 역할 | 특수 작업 |
+| **tester** | Test writing, coverage analysis | Post-implementation quality checks |
+| **reviewer** | Code review, security/performance | Pre-PR quality gate |
+| **researcher** | Codebase exploration, tech research | New tech adoption, legacy analysis |
+| **architect** | System design, API design | Large features, refactoring |
+| **devops** | CI/CD, Docker, IaC | Infrastructure, pipelines |
+| **ui-designer** | UI components, design systems | Frontend-focused work |
+| **security-auditor** | Security vulnerabilities, CVE checks | Security audits, pre-release |
+| **custom** | User-defined role | Special tasks |
 
-## 팀 정리 (Cleanup)
-
-팀 작업이 완료되면 팀원을 종료:
+## Cleaning Up
 
 ```
-/cleanup-team           # 팀원 목록 보여주고 선택
-/cleanup-team --all     # 모든 팀원 종료 + 팀 삭제
-/cleanup-team --unused  # 유휴 팀원만 종료
-/cleanup-team --default # planner/implementer만 유지, 나머지 종료
+/cleanup-team           # Show members and select who to remove
+/cleanup-team --all     # Terminate all members and delete team
+/cleanup-team --unused  # Terminate idle members only
+/cleanup-team --default # Keep planner/implementer, remove others
 ```
 
-## 전제 조건
+## Configuration
 
-- `claude -w`로 워크트리 세션 시작 필요
-- `writing-specs-plugin` 설치 권장 (planner의 spec 작성에 활용, 없어도 동작함)
+### 1M Context for Teammates
 
-## Teammate 1M Context 설정
-
-Teammate는 기본적으로 표준 Opus 모델(1M 아님)을 사용합니다. 1M context를 사용하려면:
+Teammates use the standard Opus model by default. To enable 1M context:
 
 ```bash
 export ANTHROPIC_DEFAULT_OPUS_MODEL='claude-opus-4-6[1m]'
 ```
 
-`.zshrc`에 추가하면 영구 적용됩니다.
+Add to `.zshrc` for permanent use.
 
-## 자동 설정
+### Auto-Setup
 
-팀 생성 시 자동으로 설정되는 항목:
+When a team is created, the following are configured automatically:
 - Planner: `/loop 10m /writing-specs update spec`
-- Implementer: TaskList 주기적 확인
-- 색상: 자동 할당 (프로그래밍 설정 불가)
+- Implementer: Periodic TaskList checks
+- Colors: Auto-assigned (not programmable)

--- a/brain-storm-plugin/README.md
+++ b/brain-storm-plugin/README.md
@@ -1,26 +1,26 @@
 # Brain Storm Plugin
 
-현재 코드베이스를 기반으로 미래 기능과 개선 아이디어를 브레인스토밍합니다. UI 아이디어에는 ASCII wireframe을 포함하고, 이미 구현된 아이디어는 자동 감지하여 정리합니다.
+Brainstorm future features and improvements based on the current codebase. Includes ASCII wireframes for UI ideas and auto-detects already-implemented ideas for cleanup.
 
 ## Installation
 
 ```bash
+/plugin marketplace add .
 /plugin install brain-storm-plugin@devstefancho-claude-plugins
 ```
 
 ## Trigger Keywords
 
-- 한국어: "브레인스톰", "아이디어", "기능 제안", "개선 아이디어", "뭐 만들까", "앞으로 뭐 하지"
-- English: "brainstorm", "feature ideas", "what could we build", "improvement ideas"
+- "brainstorm", "feature ideas", "what could we build", "improvement ideas"
 
 ## How It Works
 
-1. **Codebase Scan** - 프로젝트 구조와 기존 아이디어 파악
-2. **Ideation** - 3-5개 아이디어 생성 (복잡도 + UI 태그 포함)
-3. **Deduplication** - 기존 아이디어와 중복 체크
-4. **Write** - 선택된 아이디어를 템플릿으로 저장 (UI면 wireframe 포함)
-5. **Implementation Check** - 이미 구현된 아이디어 감지 후 사용자 확인 하에 삭제
-6. **Report** - 결과 요약 리포트 출력
+1. **Codebase Scan** - Analyze project structure and existing ideas
+2. **Ideation** - Generate 3-5 ideas with complexity ratings and UI tags
+3. **Deduplication** - Check against existing ideas to avoid duplicates
+4. **Write** - Save selected ideas using templates (with wireframes for UI ideas)
+5. **Implementation Check** - Detect already-implemented ideas and remove with user confirmation
+6. **Report** - Output a summary of results
 
 ## Directory Structure
 
@@ -33,14 +33,14 @@ brain-storm/
     └── dark-mode-toggle.md
 ```
 
-- 파일은 `brain-storm/`에 저장, 최대 1-depth 하위 디렉토리 허용
-- 파일명은 lowercase-with-hyphens 형식
+- Files are stored in `brain-storm/` with optional 1-depth subdirectories
+- Filenames use lowercase-with-hyphens format
 
-## writing-specs와의 차이
+## Differences from writing-specs-plugin
 
 | writing-specs | brain-storm |
 |---------------|-------------|
-| 구현할 것을 명세 | 구현할 수 있는 것을 탐색 |
-| 구체적 요구사항 | 탐색적 아이디어 |
-| Wireframe 없음 | UI 아이디어에 ASCII wireframe 포함 |
-| Outdated 감지 | 구현 완료 감지 및 정리 |
+| Specifies what **will** be built | Explores what **could** be built |
+| Structured requirements | Exploratory ideas |
+| No wireframes | ASCII wireframes for UI ideas |
+| Outdated content detection | Implementation completion detection |

--- a/computer-use-plugin/README.md
+++ b/computer-use-plugin/README.md
@@ -1,29 +1,29 @@
 # Computer Use Plugin
 
-Computer Use MCP를 활용한 앱 테스트 자동화 스킬. 시나리오 기반 테스트 + ad-hoc 탐색으로 기능/UI·UX 이슈를 발견하고 구조화된 피드백 리포트를 생성한다.
+Automates app testing using Computer Use MCP. Runs scenario-based tests and ad-hoc exploration to detect functionality, UI, and UX issues, then generates structured feedback reports.
 
 ## Installation
 
 ```bash
+/plugin marketplace add .
 /plugin install computer-use-plugin@devstefancho-claude-plugins
 ```
 
 ## Prerequisites
 
-- Computer Use MCP가 `/mcp`에서 활성화되어 있어야 함
+- Computer Use MCP must be active at `/mcp`
 
 ## Trigger Keywords
 
-- 한글: "computer use 테스트", "앱 테스트", "UI 테스트", "앱 QA"
-- 영문: "computer use test", "cu test", "app test"
+- "computer use test", "cu test", "app test", "UI test", "app QA"
 
 ## How It Works
 
-1. **Setup** - 대상 앱 확인, Computer Use MCP 권한 요청
-2. **Scenario Preparation** - 기존 시나리오 확인 또는 신규 생성
-3. **Scenario Execution** - 각 스텝을 Computer Use로 실행하며 이슈 탐지
-4. **Ad-hoc Exploration** - 시나리오 외 자유 탐색으로 추가 이슈 발견
-5. **Report** - 구조화된 피드백 리포트 생성
+1. **Setup** - Confirm target app and request Computer Use MCP permissions
+2. **Scenario Preparation** - Check existing scenarios or create new ones
+3. **Scenario Execution** - Execute each step via Computer Use, detecting issues along the way
+4. **Ad-hoc Exploration** - Free-form exploration beyond scenarios to discover additional issues
+5. **Report** - Generate a structured feedback report
 
 ## Output Structure
 
@@ -38,6 +38,6 @@ test-cases/
 
 ## Templates
 
-- `scenario-template.md` - 테스트 시나리오 (App, Preconditions, Steps)
-- `feedback-template.md` - 개별 이슈 항목 (Severity, Category, Description, Screenshot)
-- `report-template.md` - 최종 리포트 (Summary, Issues, Ad-hoc Exploration, Recommendations)
+- `scenario-template.md` - Test scenario (App, Preconditions, Steps)
+- `feedback-template.md` - Individual issue item (Severity, Category, Description, Screenshot)
+- `report-template.md` - Final report (Summary, Issues, Ad-hoc Exploration, Recommendations)

--- a/frontend-plugin/README.md
+++ b/frontend-plugin/README.md
@@ -1,51 +1,40 @@
 # Frontend Plugin
 
-React/Next.js 컴포넌트 설계 원칙 기반 코드 리뷰를 제공하는 Claude Code 플러그인입니다.
+Code review skill for React/Next.js component design based on established design principles.
 
-## 설치
+## Installation
 
 ```bash
+/plugin marketplace add .
 /plugin install frontend-plugin@devstefancho-claude-plugins
 ```
 
-## 포함된 Skills
+## Included Skills
 
 ### Component Design Reviewer
 
-React/Next.js 컴포넌트의 설계 품질을 검사하는 Skill입니다.
+Reviews the design quality of React/Next.js components against the following principles:
 
-**검사 원칙:**
-- 단일 책임 원칙 (SRP)
-- Props 설계 원칙 (Props drilling 탐지)
-- 합성(Composition) 패턴
-- 재사용성 원칙
-- Custom Hooks 분리
+- **Single Responsibility Principle (SRP)** - One component, one responsibility
+- **Props Design** - Props drilling detection and interface design
+- **Composition Pattern** - Proper use of composition over inheritance
+- **Reusability** - Component reuse opportunities
+- **Custom Hooks Separation** - Logic extraction into custom hooks
 
-**사용 예시:**
-```
-이 컴포넌트의 설계를 리뷰해주세요.
-```
+## Trigger Keywords
 
-```
-UserDashboard.tsx 파일의 컴포넌트 구조를 분석해주세요.
-```
+- "Review this component's design"
+- "Analyze the component structure of UserDashboard.tsx"
+- "Check for props drilling issues"
 
-```
-Props drilling 문제가 있는지 확인해주세요.
-```
+**Auto-activates on:**
+- React/Next.js component review requests
+- Component structure analysis
+- Props design reviews
+- Component refactoring suggestions
 
-**자동 활성화 시나리오:**
-- React/Next.js 컴포넌트 리뷰 요청
-- 컴포넌트 구조 분석 요청
-- Props 설계 검토 요청
-- 컴포넌트 리팩토링 제안
+## See Also
 
-## 관련 문서
-
-- [SKILL.md](skills/component-design-reviewer/SKILL.md) - Skill 정의
-- [PRINCIPLES.md](skills/component-design-reviewer/PRINCIPLES.md) - 원칙 상세 설명
-- [EXAMPLES.md](skills/component-design-reviewer/EXAMPLES.md) - 코드 예시
-
-## 버전
-
-- 1.0.0: 초기 릴리스 - Component Design Reviewer Skill
+- [SKILL.md](skills/component-design-reviewer/SKILL.md) - Skill definition
+- [PRINCIPLES.md](skills/component-design-reviewer/PRINCIPLES.md) - Detailed principles
+- [EXAMPLES.md](skills/component-design-reviewer/EXAMPLES.md) - Code examples

--- a/hermes-gateway-plugin/README.md
+++ b/hermes-gateway-plugin/README.md
@@ -1,0 +1,46 @@
+# Hermes Gateway Plugin
+
+Interact with Hermes Agent via local or SSH-tunneled connection. Provides commands for messaging, async task execution, health checks, and cron job management.
+
+## Installation
+
+```bash
+/plugin marketplace add .
+/plugin install hermes-gateway-plugin@devstefancho-claude-plugins
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/hermes:setup` | Check connectivity and configure connection mode |
+| `/hermes:chat` | Send a message to Hermes Agent |
+| `/hermes:run` | Start an async task with event streaming |
+| `/hermes:status` | Check connection health, tunnel status, and recent jobs |
+| `/hermes:jobs` | Manage cron jobs (list, create, delete) |
+
+## Connection Modes
+
+- **auto** (default) - Tries localhost first, falls back to SSH tunnel
+- **local** - Direct connection to `localhost:8642`
+- **ssh** - SSH tunnel to remote Hermes server
+
+## Configuration
+
+Config file: `~/.claude/hermes/config.json`
+
+Supported flags for `/hermes:setup`:
+- `--mode` - Connection mode (auto, local, ssh)
+- `--remote-host` - SSH remote host
+- `--remote-port` - Remote port
+- `--local-port` - Local port
+- `--api-key` - API key
+
+## Usage Examples
+
+```
+/hermes:setup --mode ssh --remote-host arch-server
+/hermes:chat What's the current system load?
+/hermes:run --background Analyze disk usage and report
+/hermes:jobs
+```

--- a/simple-sdd-plugin/README.md
+++ b/simple-sdd-plugin/README.md
@@ -1,0 +1,44 @@
+# Simple SDD Plugin
+
+Simple SDD (Software Specification & Design) workflow commands for generating specifications, plans, tasks, and implementations through a 4-step process.
+
+## Installation
+
+```bash
+/plugin marketplace add .
+/plugin install simple-sdd-plugin@devstefancho-claude-plugins
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/simple-sdd/spec [requirements]` | Generate a specification document |
+| `/simple-sdd/plan [tech-stack]` | Generate a technical implementation plan |
+| `/simple-sdd/tasks [context]` | Generate atomic implementation tasks |
+| `/simple-sdd/implement [--all]` | Execute tasks (batch or incremental) |
+
+## How It Works
+
+1. **Spec** - Create a comprehensive specification with user stories, requirements, and success criteria
+2. **Plan** - Generate a technical plan with architecture, data models, API design, and testing strategy
+3. **Tasks** - Break the plan into atomic tasks (ID: T-001, T-002...) with dependencies
+4. **Implement** - Execute tasks incrementally (with user approval per group) or all at once with `--all`
+
+## Output Structure
+
+```
+docs/
+├── spec-init.md      # Specification document
+├── plan-init.md      # Technical implementation plan
+└── tasks-init.md     # Atomic implementation tasks
+```
+
+## Usage Example
+
+```
+/simple-sdd/spec Build a user authentication system with OAuth support
+/simple-sdd/plan React + Node.js + PostgreSQL
+/simple-sdd/tasks
+/simple-sdd/implement --all
+```


### PR DESCRIPTION
## Summary
- Add root `README.md` with plugin catalog organized by category, quick start guide, and plugin structure overview
- Create missing READMEs for `hermes-gateway-plugin` and `simple-sdd-plugin`
- Rewrite Korean READMEs to English for `frontend-plugin`, `computer-use-plugin`, `brain-storm-plugin`, and `agent-team-plugin`
- All READMEs now include both marketplace add and plugin install commands

## Test plan
- [ ] Verify root README renders correctly on GitHub
- [ ] Verify all plugin links in root README resolve correctly
- [ ] Confirm each new/updated README has installation instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)