### PR TITLE
fix: resolve [object Object] in jobs list and translate commands to English

### DIFF
--- a/hermes-gateway-plugin/.claude-plugin/plugin.json
+++ b/hermes-gateway-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hermes",
   "description": "Interact with Hermes Agent via local or SSH-tunneled connection",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Stefan Cho"
   }

--- a/hermes-gateway-plugin/commands/chat.md
+++ b/hermes-gateway-plugin/commands/chat.md
@@ -1,5 +1,5 @@
 ---
-description: Hermes Agent에 메시지를 보내고 응답을 받는다
+description: Send a message to Hermes Agent and receive a response
 argument-hint: "<message> [--stream] [--system 'system prompt']"
 allowed-tools: Bash(node:*), AskUserQuestion
 ---

--- a/hermes-gateway-plugin/commands/jobs.md
+++ b/hermes-gateway-plugin/commands/jobs.md
@@ -1,5 +1,5 @@
 ---
-description: Hermes cron job 목록 조회, 생성, 삭제
+description: List, create, or delete Hermes cron jobs
 argument-hint: "[list|delete <id>] [--json]"
 allowed-tools: Bash(node:*), AskUserQuestion
 ---

--- a/hermes-gateway-plugin/commands/run.md
+++ b/hermes-gateway-plugin/commands/run.md
@@ -1,5 +1,5 @@
 ---
-description: Hermes Agent에 비동기 작업을 실행하고 이벤트를 스트리밍한다
+description: Run an async task on Hermes Agent and stream events
 argument-hint: "<task> [--background]"
 allowed-tools: Bash(node:*), AskUserQuestion
 ---

--- a/hermes-gateway-plugin/commands/setup.md
+++ b/hermes-gateway-plugin/commands/setup.md
@@ -1,45 +1,45 @@
 ---
-description: Hermes Agent 연결 설정 및 상태 확인 (로컬/SSH 모드 전환 지원)
+description: Configure Hermes Agent connection and check status (local/SSH mode switching)
 argument-hint: "[--mode auto|local|ssh] [--remote-host <host>] [--remote-port <port>] [--local-port <port>] [--api-key <key>]"
 allowed-tools: Bash(node:*), AskUserQuestion
 ---
 
-Hermes 연결을 설정하고 상태를 확인한다.
+Set up and verify the Hermes connection.
 
-## 인자가 없는 경우
+## No arguments
 
-연결 상태만 확인:
+Check connection status only:
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/hermes-companion.mjs" setup
 ```
 
-## 인자가 있는 경우
+## With arguments
 
-config를 업데이트하고 연결 확인:
+Update config and verify connection:
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/hermes-companion.mjs" setup $ARGUMENTS
 ```
 
-## 사용자가 설정 변경을 요청하지만 구체적 값이 없는 경우
+## When the user requests a config change without specific values
 
-AskUserQuestion으로 물어본다:
-- "어떤 모드로 변경할까요?" → choices: auto, local, ssh
-- SSH 모드 선택 시: "SSH 호스트 이름은?" (기본값: arch)
+Use AskUserQuestion to prompt:
+- "Which mode would you like to switch to?" → choices: auto, local, ssh
+- If SSH mode is selected: "What is the SSH host name?" (default: arch)
 
-## 사용 가능한 플래그
+## Available flags
 
-- `--mode auto|local|ssh` — 연결 모드 변경
-- `--remote-host <host>` — SSH 원격 호스트 (기본: arch)
-- `--remote-port <port>` — 원격 Hermes 포트 (기본: 8642)
-- `--local-port <port>` — SSH 터널 로컬 포트 (기본: 18642)
-- `--api-key <key>` — Hermes API 키 설정
+- `--mode auto|local|ssh` — Change connection mode
+- `--remote-host <host>` — SSH remote host (default: arch)
+- `--remote-port <port>` — Remote Hermes port (default: 8642)
+- `--local-port <port>` — SSH tunnel local port (default: 18642)
+- `--api-key <key>` — Set Hermes API key
 
-## 예시
+## Examples
 
-- `/hermes:setup` → 현재 연결 상태 확인
-- `/hermes:setup --mode ssh` → SSH 모드로 전환
-- `/hermes:setup --mode ssh --remote-host myserver` → SSH 모드 + 호스트 변경
-- `/hermes:setup --mode local` → 로컬 모드로 전환
-- `/hermes:setup --mode auto` → 자동 감지 모드
+- `/hermes:setup` → Check current connection status
+- `/hermes:setup --mode ssh` → Switch to SSH mode
+- `/hermes:setup --mode ssh --remote-host myserver` → SSH mode + change host
+- `/hermes:setup --mode local` → Switch to local mode
+- `/hermes:setup --mode auto` → Auto-detect mode
 
-Config 파일 위치: `~/.claude/hermes/config.json`
+Config file location: `~/.claude/hermes/config.json`

--- a/hermes-gateway-plugin/commands/status.md
+++ b/hermes-gateway-plugin/commands/status.md
@@ -1,5 +1,5 @@
 ---
-description: Hermes 연결 상태, tunnel 상태, 최근 작업 목록을 확인한다
+description: Check Hermes connection status, tunnel status, and recent jobs
 argument-hint: "[job-id] [--json]"
 allowed-tools: Bash(node:*)
 ---

--- a/hermes-gateway-plugin/scripts/lib/render.mjs
+++ b/hermes-gateway-plugin/scripts/lib/render.mjs
@@ -100,10 +100,14 @@ export function renderJobs(jobs) {
   }
 
   const lines = ["# Hermes Cron Jobs\n"];
-  lines.push("| ID | Schedule | Status |");
-  lines.push("|---|---|---|");
+  lines.push("| ID | Name | Schedule | Status |");
+  lines.push("|---|---|---|---|");
   for (const job of jobs) {
-    lines.push(`| ${job.id || job.job_id} | ${job.schedule || job.cron || "N/A"} | ${job.status || "active"} |`);
+    const sched = job.schedule_display
+      || (typeof job.schedule === "object" ? (job.schedule?.display || job.schedule?.expr || JSON.stringify(job.schedule)) : job.schedule)
+      || job.cron
+      || "N/A";
+    lines.push(`| ${job.id || job.job_id} | ${job.name || "-"} | ${sched} | ${job.status || job.state || "active"} |`);
   }
   return lines.join("\n");
 }


### PR DESCRIPTION
## Summary
- Fix `renderJobs` showing `[object Object]` for schedule field by properly extracting `schedule_display` or `schedule.display`/`schedule.expr` from the API response object
- Add `name` column to jobs table output
- Translate all Korean command descriptions and `setup.md` body to English
- Bump hermes plugin version to 1.0.1

## Test plan
- [x] Run `/hermes:jobs` and verify schedule shows cron expression (e.g. `0 8 * * 1-5`)
- [x] Verify job name is displayed in the table
- [x] Check all command descriptions show in English via `/help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)