### PR TITLE
Clarify async run status checking guidance

### DIFF
--- a/hermes-gateway-plugin/commands/run.md
+++ b/hermes-gateway-plugin/commands/run.md
@@ -16,4 +16,11 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/hermes-companion.mjs" run $ARGUMENTS
 - Without `--background`: stream events until completion and return output verbatim
 - With `--background`: return the job ID immediately so the user can check status later
 
+## Important: Status check guidance
+
+- **Async runs** (created by `/hermes:run`): check status with `/hermes:status [job-id]`
+- **Cron jobs** (scheduled repeating tasks): list with `/hermes:jobs`
+
+These are different concepts. NEVER tell the user to use `/hermes:jobs` to check the status of an async run. Always guide them to `/hermes:status`.
+
 Return the output verbatim. Do not paraphrase or summarize.

--- a/hermes-gateway-plugin/commands/run.md
+++ b/hermes-gateway-plugin/commands/run.md
@@ -18,7 +18,7 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/hermes-companion.mjs" run $ARGUMENTS
 
 ## Important: Status check guidance
 
-- **Async runs** (created by `/hermes:run`): check status with `/hermes:status [job-id]`
+- **Async runs** (created by `/hermes:run`): check status with `/hermes:status latest` or `/hermes:status [job-id]`
 - **Cron jobs** (scheduled repeating tasks): list with `/hermes:jobs`
 
 These are different concepts. NEVER tell the user to use `/hermes:jobs` to check the status of an async run. Always guide them to `/hermes:status`.

--- a/hermes-gateway-plugin/commands/status.md
+++ b/hermes-gateway-plugin/commands/status.md
@@ -1,6 +1,6 @@
 ---
 description: Check Hermes connection status, tunnel status, and recent jobs
-argument-hint: "[job-id] [--json]"
+argument-hint: "[job-id | latest] [--json]"
 allowed-tools: Bash(node:*)
 ---
 
@@ -10,5 +10,11 @@ Execute:
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/hermes-companion.mjs" status $ARGUMENTS
 ```
+
+## Usage
+
+- No arguments: shows connection status + recent jobs list
+- `latest`: shows details of the most recent async run
+- `<job-id>`: shows details of a specific job
 
 Return the output verbatim.

--- a/hermes-gateway-plugin/scripts/hermes-companion.mjs
+++ b/hermes-gateway-plugin/scripts/hermes-companion.mjs
@@ -182,8 +182,10 @@ async function cmdStatus(flags, text) {
   const jobs = state.listJobRecords();
 
   if (text) {
-    // status for a specific job/run
-    const job = state.readJobRecord(text);
+    // "latest" shortcut resolves to the most recent job
+    const job = text === "latest"
+      ? state.getLatestJobRecord()
+      : state.readJobRecord(text);
     if (job) {
       output(flags.json ? job : JSON.stringify(job, null, 2), flags.json);
     } else {

--- a/hermes-gateway-plugin/scripts/lib/render.mjs
+++ b/hermes-gateway-plugin/scripts/lib/render.mjs
@@ -48,7 +48,7 @@ export function renderRunStarted(runInfo) {
   const lines = [];
   lines.push(`**Run started:** ${runInfo.run_id || runInfo.id}`);
   lines.push(`**Status:** ${runInfo.status}`);
-  lines.push(`\nCheck status with \`/hermes:status\``);
+  lines.push(`\nCheck status with \`/hermes:status latest\``);
   return lines.join("\n");
 }
 

--- a/hermes-gateway-plugin/scripts/lib/render.mjs
+++ b/hermes-gateway-plugin/scripts/lib/render.mjs
@@ -48,6 +48,7 @@ export function renderRunStarted(runInfo) {
   const lines = [];
   lines.push(`**Run started:** ${runInfo.run_id || runInfo.id}`);
   lines.push(`**Status:** ${runInfo.status}`);
+  lines.push(`\nCheck status with \`/hermes:status\``);
   return lines.join("\n");
 }
 

--- a/hermes-gateway-plugin/scripts/lib/state.mjs
+++ b/hermes-gateway-plugin/scripts/lib/state.mjs
@@ -95,6 +95,13 @@ export function listJobRecords() {
   return manifest.jobs;
 }
 
+export function getLatestJobRecord() {
+  const manifest = loadManifest();
+  if (manifest.jobs.length === 0) return null;
+  const latest = manifest.jobs[manifest.jobs.length - 1];
+  return readJobRecord(latest.id);
+}
+
 export function appendLog(id, line) {
   ensureDirs();
   fs.appendFileSync(path.join(LOGS_DIR, `${id}.log`), line + "\n");


### PR DESCRIPTION
## Summary
This PR improves user guidance for checking the status of async runs by clarifying the distinction between async runs and cron jobs, and ensuring users are directed to the correct command.

## Key Changes
- **Documentation update** (`run.md`): Added a new "Important: Status check guidance" section that explicitly distinguishes between async runs (checked with `/hermes:status [job-id]`) and cron jobs (listed with `/hermes:jobs`), with a clear warning against conflating the two concepts
- **UI improvement** (`render.mjs`): Updated the `renderRunStarted()` function to include a helpful hint directing users to use `/hermes:status` when an async run is initiated

## Implementation Details
The changes address a potential user confusion point by:
1. Making it explicit in documentation that `/hermes:jobs` is for cron jobs only, not for checking individual async run status
2. Providing immediate in-context guidance when a run starts, so users know the correct next step without having to reference documentation
3. Preventing users from being misdirected to the wrong command for status checks

https://claude.ai/code/session_0157WGmEVW8TfgvULjRTcftC