### PR TITLE
feat: LLM Wiki 플러그인 추가

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -109,6 +109,11 @@
       "name": "agent-team-plugin",
       "source": "./agent-team-plugin",
       "description": "Agent team management - create, expand, and cleanup teams for worktree sessions"
+    },
+    {
+      "name": "llm-wiki-plugin",
+      "source": "./llm-wiki-plugin",
+      "description": "LLM-maintained personal wiki with ingest, query, lint, update operations"
     }
   ]
 }

--- a/llm-wiki-plugin/.claude-plugin/plugin.json
+++ b/llm-wiki-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "llm-wiki-plugin",
+  "description": "LLM-maintained personal wiki with ingest, query, lint, update operations",
+  "version": "1.0.0",
+  "author": {
+    "name": "Stefan Cho"
+  }
+}

--- a/llm-wiki-plugin/README.md
+++ b/llm-wiki-plugin/README.md
@@ -1,0 +1,58 @@
+# LLM Wiki Plugin
+
+Andrej Karpathy의 LLM Wiki 패턴을 Claude Code 스킬로 구현. LLM이 raw 소스를 읽고 마크다운 위키로 컴파일하여 지식을 축적하는 개인 위키 시스템.
+
+## Installation
+
+```bash
+/plugin marketplace add .
+/plugin install llm-wiki-plugin@devstefancho-claude-plugins
+```
+
+## Trigger Keywords
+
+`wiki init`, `wiki ingest`, `wiki query`, `wiki lint`, `wiki update`, `위키 초기화`, `위키 추가`, `위키 질문`, `위키 검사`, `위키 수정`
+
+## Operations
+
+### `wiki init` — 새 위키 도메인 생성
+도메인명, 설명, 소스 유형을 입력받아 위키 구조를 초기화합니다.
+
+### `wiki ingest <source>` — 소스 추가
+파일, URL, 텍스트를 읽어 위키 페이지로 컴파일합니다. 관련 페이지를 자동 업데이트하고 양방향 백링크를 생성합니다.
+
+### `wiki query <question>` — 위키 검색
+위키를 기반으로 질문에 답변하며 `[[slug]]` 인용을 포함합니다. 답변을 위키 페이지로 저장할 수 있습니다.
+
+### `wiki lint` — 위키 건강 검사
+broken links, orphan pages, missing backlinks, stale pages 등을 검출하고 자동 수정을 제안합니다.
+
+### `wiki update <page>` — 페이지 수정
+특정 페이지를 수정하고 연관 페이지의 모순을 체크합니다.
+
+## Directory Structure
+
+```
+{wiki_root}/
+└── {domain}/
+    ├── SCHEMA.md          # 위키 규약
+    ├── raw/               # 원본 소스 (불변)
+    └── wiki/
+        ├── index.md       # 페이지 카탈로그
+        ├── overview.md    # 도메인 요약
+        ├── log.md         # 작업 이력 (append-only)
+        └── pages/         # 위키 페이지 (flat)
+            └── {slug}.md
+```
+
+## Configuration
+
+최초 실행 시 위키 루트 경로를 설정합니다. 설정은 `config.json`에 저장됩니다.
+
+```json
+{ "wiki_root": "~/wiki" }
+```
+
+## Design
+
+Based on [Andrej Karpathy's LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — 3-layer architecture with compiled knowledge that accumulates over time.

--- a/llm-wiki-plugin/config.example.json
+++ b/llm-wiki-plugin/config.example.json
@@ -1,0 +1,3 @@
+{
+  "wiki_root": "~/wiki"
+}

--- a/llm-wiki-plugin/skills/llm-wiki/PRINCIPLES.md
+++ b/llm-wiki-plugin/skills/llm-wiki/PRINCIPLES.md
@@ -1,0 +1,85 @@
+# LLM Wiki Principles
+
+## 3-Layer Architecture
+
+### Layer 1: Raw Sources (`raw/`)
+- **Immutable** — 한 번 저장된 소스는 절대 수정하지 않는다
+- 논문, 기사, URL 스냅샷, 트랜스크립트, 노트 등 원본 자료
+- 형식: `raw/{slug}.md` 또는 `raw/{slug}.pdf`
+- LLM은 읽기만 가능, 쓰기 불가
+
+### Layer 2: Wiki (`wiki/`)
+- LLM이 생성하고 유지보수하는 컴파일된 지식
+- 구조:
+  - `wiki/index.md` — 전체 페이지 카탈로그 (매 operation마다 갱신)
+  - `wiki/overview.md` — 도메인 전체 요약 (이해가 바뀔 때 갱신)
+  - `wiki/log.md` — append-only 작업 이력
+  - `wiki/pages/{slug}.md` — 개별 위키 페이지 (flat 구조, 하위 디렉토리 없음)
+
+### Layer 3: Schema (`SCHEMA.md`)
+- 위키의 계약서. 도메인, 규약, 페이지 유형을 정의
+- 스킬이 위키를 발견하고 이해하는 진입점
+
+## Page Frontmatter
+
+모든 위키 페이지는 YAML frontmatter로 시작한다:
+
+```yaml
+---
+title: Page Title
+slug: page-title
+type: source | entity | concept
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+sources: [slug1, slug2]
+tags: [tag1, tag2]
+---
+```
+
+### 필수 필드
+- `title`: 페이지 제목
+- `slug`: 파일명과 동일 (확장자 제외)
+- `type`: source(원본 요약), entity(사람/도구/조직), concept(아이디어/패턴)
+- `created`: 생성일
+- `updated`: 최종 수정일
+
+### 선택 필드
+- `sources`: 이 페이지가 참조하는 소스 slug 목록
+- `tags`: 분류 태그
+
+## Wikilink Format
+
+- 기본: `[[slug]]` → `wiki/pages/{slug}.md`로 연결
+- 커스텀 표시: `[[slug|표시 텍스트]]`
+- 위키 내부 링크에만 사용. 외부 URL은 일반 마크다운 링크 사용
+
+## Bidirectional Linking Policy
+
+- A 페이지가 B를 `[[B]]`로 참조하면, B 페이지의 Related 섹션에도 `[[A]]`가 있어야 함
+- Ingest 시 새 페이지 작성 후 반드시 **백링크 감사** 수행
+- Grep으로 전체 `wiki/pages/`를 스캔하여 누락된 역방향 링크 추가
+
+## Slug Rules
+
+- lowercase-with-hyphens만 허용
+- 최대 50자
+- 특수문자 불가 (알파벳, 숫자, 하이픈만)
+- 예: "Attention Is All You Need" → `attention-is-all-you-need`
+- 충돌 시 숫자 접미사: `concept-2`
+
+## Immutability Rules
+
+1. **`raw/` 불변**: 소스 파일은 추가만 가능, 수정/삭제 불가
+2. **`log.md` append-only**: 기존 로그 항목을 수정하거나 삭제하지 않음. 항상 맨 아래에 추가
+3. **SCHEMA.md 보존**: 사용자 확인 없이 SCHEMA.md를 수정하지 않음
+
+## Log Entry Format
+
+```markdown
+## [YYYY-MM-DD] <operation> | <description>
+- Pages created: [[slug1]], [[slug2]]
+- Pages updated: [[slug3]], [[slug4]]
+- Backlinks added: <count>
+```
+
+Operations: `init`, `ingest`, `query`, `lint`, `update`

--- a/llm-wiki-plugin/skills/llm-wiki/SKILL.md
+++ b/llm-wiki-plugin/skills/llm-wiki/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: llm-wiki
+description: Maintain an LLM-powered personal wiki from raw sources. Use when user mentions wiki init, wiki ingest, wiki query, wiki lint, wiki update, 위키 초기화, 위키 추가, 위키 질문, 위키 검사, 위키 업데이트, or wants to build a knowledge base from sources.
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch, AskUserQuestion
+context: fork
+agent: general-purpose
+---
+
+# LLM Wiki
+
+Manages an LLM-maintained personal wiki using the 3-layer architecture (raw sources → wiki pages → schema). The wiki compiles knowledge from raw sources into interconnected markdown pages that accumulate over time.
+
+Read [PRINCIPLES.md](PRINCIPLES.md) for linking rules, frontmatter conventions, and immutability rules.
+
+## Phase 0: Config Discovery
+
+Every operation starts here. Find the wiki root path.
+
+1. Determine the plugin install directory (where this SKILL.md lives)
+2. Check if `config.json` exists in the plugin root (2 levels up from SKILL.md):
+   - **Exists**: Read `wiki_root` value
+   - **Not exists**: Ask user with `AskUserQuestion`:
+     > 위키 루트 경로를 설정해주세요. 모든 위키 도메인이 이 경로 하위에 생성됩니다.
+     > 기본값: `~/wiki`
+   - Create `config.json` with the user's answer: `{ "wiki_root": "<path>" }`
+3. Expand `~` to absolute path
+
+```json
+// config.json
+{ "wiki_root": "~/wiki" }
+```
+
+## Phase 1: Domain Discovery
+
+After config is loaded, find the target wiki domain.
+
+1. Run `Glob {wiki_root}/*/SCHEMA.md` to find all domains
+2. **No domains found**:
+   - If operation is `init` → proceed to init
+   - Otherwise → inform user: "위키가 없습니다. 먼저 `wiki init`을 실행해주세요."
+3. **One domain found**: Use it automatically
+4. **Multiple domains found**: Ask user to select with `AskUserQuestion`:
+   > 여러 위키 도메인이 있습니다. 어떤 도메인에서 작업할까요?
+   > 1. {domain_1}
+   > 2. {domain_2}
+5. Read `SCHEMA.md` of selected domain for conventions
+
+## Operation: init
+
+Creates a new wiki domain under the wiki root.
+
+### Steps
+
+1. Ensure Phase 0 is complete (config.json exists)
+2. Ask user with `AskUserQuestion`:
+   > 새 위키 도메인을 생성합니다.
+   > - **도메인명** (디렉토리명으로 사용, lowercase-with-hyphens): 
+   > - **도메인 설명** (한 줄):
+   > - **소스 유형** (예: papers, articles, videos, code):
+3. Create directory structure:
+   ```
+   {wiki_root}/{domain}/
+   ├── SCHEMA.md
+   ├── raw/
+   └── wiki/
+       ├── index.md
+       ├── overview.md
+       ├── log.md
+       └── pages/
+   ```
+4. Generate files from templates:
+   - `SCHEMA.md` ← [templates/schema-template.md](templates/schema-template.md) (fill domain, description, source types, today's date)
+   - `wiki/index.md` ← [templates/index-template.md](templates/index-template.md) (fill domain, today's date)
+   - `wiki/overview.md` ← [templates/overview-template.md](templates/overview-template.md) (fill domain, description, today's date)
+   - `wiki/log.md` ← initial content:
+     ```markdown
+     # Wiki Log
+     
+     Append-only operation record.
+     
+     ---
+     
+     ## [{today}] init | {domain}
+     - Wiki created at `{wiki_root}/{domain}/`
+     ```
+5. Report to user:
+   > ✅ 위키 도메인 `{domain}` 생성 완료
+   > - 경로: `{wiki_root}/{domain}/`
+   > - 다음 단계: `wiki ingest <source>` 로 소스를 추가하세요
+
+## Operation: ingest
+
+Processes a new source and integrates it into the wiki.
+
+### Steps
+
+1. **Accept source** — determine source type from user input:
+   - File path → `Read` the file
+   - URL → `WebFetch` the content. If WebFetch unavailable, ask user to paste content
+   - Pasted text → use directly
+2. **Save raw source**:
+   - Generate slug from source title (see PRINCIPLES.md slug rules)
+   - Save to `raw/{slug}.md` with metadata header:
+     ```markdown
+     ---
+     source_url: {url_if_applicable}
+     ingested: {today}
+     type: {article|paper|video|code|note}
+     ---
+     
+     {full_source_content}
+     ```
+3. **Surface takeaways** — present to user with `AskUserQuestion`:
+   > 📖 **{source_title}** 분석 완료
+   >
+   > **핵심 포인트:**
+   > 1. {takeaway_1}
+   > 2. {takeaway_2}
+   > 3. {takeaway_3}
+   >
+   > **관련 엔티티/개념:** {entity_list}
+   >
+   > 강조하거나 제외할 내용이 있나요? (없으면 Enter)
+4. **Write source summary page**:
+   - Use [templates/page-template.md](templates/page-template.md)
+   - `type: source`
+   - Include: URL/path, ingest date, 2-3 paragraph synthesis, key takeaways, entity/concept links
+5. **Update entity/concept pages**:
+   - For each entity/concept mentioned in the source:
+     - `Grep` for existing page in `wiki/pages/`
+     - **Exists**: Read page, append source to `sources` frontmatter, add new information to content, update `updated` date
+     - **Not exists**: Create new page with `type: entity` or `type: concept`
+6. **Bidirectional backlink audit** (CRITICAL):
+   - For every `[[slug]]` in newly created/updated pages:
+     - Read target page
+     - If target doesn't link back → add `[[new-slug]]` to target's Related section
+   - `Grep` all files in `wiki/pages/` for mentions of entities/concepts from the new source that lack `[[links]]`
+   - Add missing wikilinks
+7. **Update index.md**:
+   - Read current `wiki/index.md`
+   - Add entry under appropriate category (Sources/Entities/Concepts):
+     `- [[{slug}]] — {one-line summary} _(ingested {today})_`
+   - Update Recent section with latest 5 entries
+8. **Update overview.md**:
+   - Read current `wiki/overview.md`
+   - If new source shifts understanding: update Key Themes, add Open Questions
+   - Update Statistics counts
+   - Update `updated` frontmatter date
+9. **Append to log.md** (no user confirmation needed):
+   ```markdown
+   ## [{today}] ingest | {source_title}
+   - Pages created: [[{slug1}]], [[{slug2}]]
+   - Pages updated: [[{slug3}]], [[{slug4}]]
+   - Backlinks added: {count}
+   ```
+10. **Report**:
+    > ✅ **{source_title}** ingest 완료
+    > - 소스 페이지: `[[{slug}]]`
+    > - 생성된 페이지: {count}개
+    > - 업데이트된 페이지: {count}개
+    > - 추가된 백링크: {count}개
+
+## Operation: query
+
+Searches the wiki and synthesizes an answer with citations.
+
+### Steps
+
+1. **Index scan**:
+   - Read `wiki/index.md` completely
+   - Identify relevant pages from the user's question
+   - Prioritize wiki content over general knowledge
+2. **Page retrieval**:
+   - Read full content of identified pages
+   - Follow `[[cross-references]]` up to 2 hops where relevant
+   - Build comprehensive context
+3. **Synthesize answer**:
+   - Ground all claims in wiki sources using inline `[[slug]]` citations
+   - Note agreements/disagreements between pages
+   - Explicitly flag gaps: "위키에 {topic}에 대한 내용이 없습니다"
+   - Format appropriately: prose for facts, tables for comparisons, numbered steps for procedures
+4. **Offer archival** with `AskUserQuestion`:
+   > 이 답변을 위키 페이지로 저장할까요?
+   > 제안 slug: `{suggested-slug}`
+   - **Yes**: Create page with `type: concept`, tags `[query, analysis]`, run mini-ingest (update index, log, backlinks)
+   - **No**: Log only:
+     ```
+     ## [{today}] query | {question_summary} (not filed)
+     ```
+
+## Operation: lint
+
+Audits wiki health and offers fixes.
+
+### Steps
+
+1. **Build inventory**:
+   - `Glob wiki/pages/*.md` for all pages
+   - Read `wiki/index.md` and `wiki/overview.md`
+   - Collect: all slugs, all `[[slug]]` references, all frontmatter fields
+2. **Run checks**:
+
+   **🔴 Errors** (must fix):
+   - Broken links: `[[slug]]` with no corresponding file
+   - Missing frontmatter: absent `title`, `slug`, `type`, `created`, or `updated`
+   - Invalid slug: not lowercase-with-hyphens
+
+   **🟡 Warnings** (should fix):
+   - Orphan pages: zero inbound links (exclude index, overview)
+   - Missing backlinks: A→B exists but B→A doesn't
+   - Stale pages: `updated` older than 90 days with temporal language ("current", "latest", "recent")
+
+   **🔵 Info**:
+   - Missing concept pages: entity/concept mentioned 3+ times without dedicated page
+   - Index gaps: pages exist but not listed in index.md
+
+3. **Output report**:
+   > 📋 **Wiki Lint Report** ({today})
+   >
+   > **Pages scanned:** {count}
+   >
+   > 🔴 **Errors ({count})**
+   > {error_list}
+   >
+   > 🟡 **Warnings ({count})**
+   > {warning_list}
+   >
+   > 🔵 **Info ({count})**
+   > {info_list}
+
+4. **Offer fixes** with `AskUserQuestion`:
+   > 자동 수정 가능한 항목이 {count}개 있습니다. 수정할까요?
+   > - Broken links 제거/수정
+   > - Missing backlinks 추가
+   > - Index 누락 항목 추가
+   > - Missing frontmatter 채우기
+   - If accepted: apply fixes, report what changed
+   - If declined: skip
+
+5. **Append to log.md**:
+   ```
+   ## [{today}] lint | {error_count} errors, {warning_count} warnings, {info_count} info
+   Fixed: {list_of_fixes_or_none}
+   ```
+
+## Operation: update
+
+Revises wiki pages when knowledge changes or contradictions arise.
+
+### Steps
+
+1. **Identify targets**:
+   - From user's request: specific page names, topics, or from lint recommendations
+   - `Grep` to locate relevant pages in `wiki/pages/`
+2. **Propose changes**:
+   - For each target page, show:
+     > **{page_title}** (`[[{slug}]]`)
+     > - 현재: `{current_text}`
+     > - 변경: `{proposed_text}`
+     > - 이유: {reason}
+   - Wait for user confirmation via `AskUserQuestion`
+3. **Apply edits**:
+   - Use `Edit` to modify pages
+   - Update `updated` frontmatter date to today
+4. **Contradiction check**:
+   - `Grep` all pages for claims related to the updated content
+   - Flag conflicting assertions
+   - Offer to update those pages too
+5. **Update metadata**:
+   - Revise index.md summary if the page's purpose changed
+   - Update overview.md if the update shifts overall understanding
+6. **Append to log.md**:
+   ```
+   ## [{today}] update | [[{slug1}]], [[{slug2}]]
+   Reason: {explanation}
+   Changes: {brief_summary}
+   ```
+
+## Operation Detection
+
+Parse user intent into an operation:
+
+| User says | Operation |
+|-----------|-----------|
+| "wiki init", "위키 초기화", "위키 만들어" | init |
+| URL, file path, "ingest", "위키 추가", "이거 읽어줘" | ingest |
+| Question about wiki content, "wiki query", "위키에서 찾아줘" | query |
+| "wiki lint", "위키 검사", "위키 건강 체크" | lint |
+| "wiki update", "위키 수정", specific page + change intent | update |
+
+If ambiguous, ask with `AskUserQuestion`:
+> 어떤 작업을 할까요?
+> 1. ingest — 새 소스 추가
+> 2. query — 위키에서 검색
+> 3. lint — 위키 건강 검사
+> 4. update — 페이지 수정

--- a/llm-wiki-plugin/skills/llm-wiki/SKILL.md
+++ b/llm-wiki-plugin/skills/llm-wiki/SKILL.md
@@ -44,6 +44,7 @@ After config is loaded, find the target wiki domain.
    > 1. {domain_1}
    > 2. {domain_2}
 5. Read `SCHEMA.md` of selected domain for conventions
+6. Set `{domain_path}` = `{wiki_root}/{domain}` — all subsequent paths in operations are relative to this absolute path
 
 ## Operation: init
 
@@ -100,7 +101,7 @@ Processes a new source and integrates it into the wiki.
    - Pasted text → use directly
 2. **Save raw source**:
    - Generate slug from source title (see PRINCIPLES.md slug rules)
-   - Save to `raw/{slug}.md` with metadata header:
+   - **Text/markdown content** → save to `{domain_path}/raw/{slug}.md` with metadata header:
      ```markdown
      ---
      source_url: {url_if_applicable}
@@ -110,6 +111,7 @@ Processes a new source and integrates it into the wiki.
      
      {full_source_content}
      ```
+   - **Binary files (PDF, images)** → copy original to `{domain_path}/raw/{slug}.{ext}` preserving format, then create a companion `{domain_path}/raw/{slug}.meta.md` with the metadata header above (content field = file path reference)
 3. **Surface takeaways** — present to user with `AskUserQuestion`:
    > 📖 **{source_title}** 분석 완료
    >
@@ -127,22 +129,22 @@ Processes a new source and integrates it into the wiki.
    - Include: URL/path, ingest date, 2-3 paragraph synthesis, key takeaways, entity/concept links
 5. **Update entity/concept pages**:
    - For each entity/concept mentioned in the source:
-     - `Grep` for existing page in `wiki/pages/`
+     - `Grep` for existing page in `{domain_path}/wiki/pages/`
      - **Exists**: Read page, append source to `sources` frontmatter, add new information to content, update `updated` date
      - **Not exists**: Create new page with `type: entity` or `type: concept`
 6. **Bidirectional backlink audit** (CRITICAL):
    - For every `[[slug]]` in newly created/updated pages:
      - Read target page
      - If target doesn't link back → add `[[new-slug]]` to target's Related section
-   - `Grep` all files in `wiki/pages/` for mentions of entities/concepts from the new source that lack `[[links]]`
+   - `Grep` all files in `{domain_path}/wiki/pages/` for mentions of entities/concepts from the new source that lack `[[links]]`
    - Add missing wikilinks
 7. **Update index.md**:
-   - Read current `wiki/index.md`
+   - Read current `{domain_path}/wiki/index.md`
    - Add entry under appropriate category (Sources/Entities/Concepts):
      `- [[{slug}]] — {one-line summary} _(ingested {today})_`
    - Update Recent section with latest 5 entries
 8. **Update overview.md**:
-   - Read current `wiki/overview.md`
+   - Read current `{domain_path}/wiki/overview.md`
    - If new source shifts understanding: update Key Themes, add Open Questions
    - Update Statistics counts
    - Update `updated` frontmatter date
@@ -167,7 +169,7 @@ Searches the wiki and synthesizes an answer with citations.
 ### Steps
 
 1. **Index scan**:
-   - Read `wiki/index.md` completely
+   - Read `{domain_path}/wiki/index.md` completely
    - Identify relevant pages from the user's question
    - Prioritize wiki content over general knowledge
 2. **Page retrieval**:
@@ -195,8 +197,8 @@ Audits wiki health and offers fixes.
 ### Steps
 
 1. **Build inventory**:
-   - `Glob wiki/pages/*.md` for all pages
-   - Read `wiki/index.md` and `wiki/overview.md`
+   - `Glob {domain_path}/wiki/pages/*.md` for all pages
+   - Read `{domain_path}/wiki/index.md` and `{domain_path}/wiki/overview.md`
    - Collect: all slugs, all `[[slug]]` references, all frontmatter fields
 2. **Run checks**:
 
@@ -251,7 +253,7 @@ Revises wiki pages when knowledge changes or contradictions arise.
 
 1. **Identify targets**:
    - From user's request: specific page names, topics, or from lint recommendations
-   - `Grep` to locate relevant pages in `wiki/pages/`
+   - `Grep` to locate relevant pages in `{domain_path}/wiki/pages/`
 2. **Propose changes**:
    - For each target page, show:
      > **{page_title}** (`[[{slug}]]`)

--- a/llm-wiki-plugin/skills/llm-wiki/templates/index-template.md
+++ b/llm-wiki-plugin/skills/llm-wiki/templates/index-template.md
@@ -1,0 +1,24 @@
+---
+title: Index
+slug: index
+type: index
+updated: {date}
+---
+
+# {domain} Wiki Index
+
+## Sources
+
+_(No sources yet)_
+
+## Entities
+
+_(No entities yet)_
+
+## Concepts
+
+_(No concepts yet)_
+
+## Recent
+
+_(No activity yet)_

--- a/llm-wiki-plugin/skills/llm-wiki/templates/index-template.md
+++ b/llm-wiki-plugin/skills/llm-wiki/templates/index-template.md
@@ -2,6 +2,7 @@
 title: Index
 slug: index
 type: index
+created: {date}
 updated: {date}
 ---
 

--- a/llm-wiki-plugin/skills/llm-wiki/templates/overview-template.md
+++ b/llm-wiki-plugin/skills/llm-wiki/templates/overview-template.md
@@ -2,6 +2,7 @@
 title: Overview
 slug: overview
 type: index
+created: {date}
 updated: {date}
 ---
 

--- a/llm-wiki-plugin/skills/llm-wiki/templates/overview-template.md
+++ b/llm-wiki-plugin/skills/llm-wiki/templates/overview-template.md
@@ -1,0 +1,28 @@
+---
+title: Overview
+slug: overview
+type: index
+updated: {date}
+---
+
+# {domain} Wiki Overview
+
+## Scope
+
+{scope_description}
+
+## Key Themes
+
+_(Themes will emerge as sources are ingested)_
+
+## Open Questions
+
+_(Questions will be added as the wiki grows)_
+
+## Statistics
+
+- Total pages: 0
+- Sources: 0
+- Entities: 0
+- Concepts: 0
+- Last updated: {date}

--- a/llm-wiki-plugin/skills/llm-wiki/templates/page-template.md
+++ b/llm-wiki-plugin/skills/llm-wiki/templates/page-template.md
@@ -1,0 +1,27 @@
+---
+title: {title}
+slug: {slug}
+type: {type}
+created: {date}
+updated: {date}
+sources: [{source_slugs}]
+tags: [{tags}]
+---
+
+# {title}
+
+{source_meta}
+
+## Summary
+
+{summary}
+
+## Key Points
+
+- {point_1}
+- {point_2}
+- {point_3}
+
+## Related
+
+{backlinks}

--- a/llm-wiki-plugin/skills/llm-wiki/templates/schema-template.md
+++ b/llm-wiki-plugin/skills/llm-wiki/templates/schema-template.md
@@ -1,0 +1,41 @@
+# {domain} Wiki Schema
+
+## Identity
+- **Domain:** {domain_description}
+- **Created:** {date}
+- **Source types:** {source_types}
+
+## Page Types
+- **source**: 원본 자료 요약 (논문, 기사, 영상 등)
+- **entity**: 사람, 조직, 도구, 기술
+- **concept**: 아이디어, 패턴, 원칙
+
+## Frontmatter Format
+```yaml
+---
+title: Page Title
+slug: page-title
+type: source | entity | concept
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+sources: [slug1, slug2]
+tags: [tag1, tag2]
+---
+```
+
+## Cross-References
+- Internal links: `[[slug]]` or `[[slug|display text]]`
+- slug = filename without `.md`
+- All links must be bidirectional
+
+## Index Categories
+- Sources
+- Entities
+- Concepts
+
+## Governance Rules (immutable)
+1. `raw/` is immutable — never modify source files
+2. `log.md` is append-only — never rewrite, only append
+3. `index.md` updates with every operation adding/changing pages
+4. `wiki/pages/` is flat — all pages as `{slug}.md`, NO subdirectories
+5. `overview.md` reflects current synthesis across all sources


### PR DESCRIPTION
## Summary
- Karpathy LLM Wiki 패턴 기반 개인 위키 스킬 플러그인 추가
- 5개 operation: init, ingest, query, lint, update
- 3-layer 아키텍처 (raw sources → wiki pages → schema)로 지식 축적

## Test plan
- [ ] `/plugin marketplace add .` → `/plugin install llm-wiki-plugin@devstefancho-claude-plugins` 설치 확인
- [ ] `wiki init` → 디렉토리 구조 + SCHEMA.md 생성 확인
- [ ] `wiki ingest <URL>` → 페이지 생성 + 백링크 + index/log 업데이트 확인
- [ ] `wiki query <질문>` → 인용 포함 답변 확인
- [ ] `wiki lint` → 리포트 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)