### PR TITLE
feat: add design-brief-driven UI prototype workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -68,7 +68,7 @@
     {
       "name": "frontend-plugin",
       "source": "./frontend-plugin",
-      "description": "React.js 프론트엔드 개발을 위한 코드 리뷰 및 설계 원칙 검사 플러그인"
+      "description": "Frontend code review and design-principles plugin for React.js development"
     },
     {
       "name": "smart-commit-plugin",
@@ -103,7 +103,7 @@
     {
       "name": "brain-storm-plugin",
       "source": "./brain-storm-plugin",
-      "description": "Brainstorm future features and improvements with wireframes and implementation detection"
+      "description": "Brainstorm future features and improvements, then generate standalone HTML previews for UI ideas"
     },
     {
       "name": "agent-team-plugin",

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A collection of reusable [Claude Code](https://claude.ai/code) plugins — slash
 | [writing-specs-plugin](./writing-specs-plugin) | Spec writing with conflict detection and reporting |
 | [simple-sdd-plugin](./simple-sdd-plugin) | SDD workflow: spec → plan → tasks → implement |
 | [implement-with-test-plugin](./implement-with-test-plugin) | Implement code with tests from specs or direct requests |
-| [brain-storm-plugin](./brain-storm-plugin) | Brainstorm features and improvements with wireframes |
+| [brain-storm-plugin](./brain-storm-plugin) | Brainstorm features and improvements with wireframes and HTML prototype previews |
 
 ### Git & Workflow
 
@@ -77,7 +77,7 @@ A collection of reusable [Claude Code](https://claude.ai/code) plugins — slash
 
 Each plugin follows this layout:
 
-```
+```text
 plugin-name/
 ├── .claude-plugin/
 │   └── plugin.json         # Plugin metadata (required)

--- a/brain-storm-plugin/.claude-plugin/plugin.json
+++ b/brain-storm-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "brain-storm-plugin",
-  "description": "Brainstorm future features and improvements with wireframes and implementation detection",
-  "version": "1.0.0",
+  "description": "Brainstorm future features and improvements, then generate standalone HTML previews for UI ideas",
+  "version": "1.2.0",
   "author": {
     "name": "Stefan Cho"
   }

--- a/brain-storm-plugin/README.md
+++ b/brain-storm-plugin/README.md
@@ -1,6 +1,6 @@
 # Brain Storm Plugin
 
-Brainstorm future features and improvements based on the current codebase. Includes ASCII wireframes for UI ideas and auto-detects already-implemented ideas for cleanup.
+Brainstorm future features and improvements based on the current codebase, then generate standalone HTML previews for UI-heavy ideas. This plugin packages both ideation and prototype-preview workflows into one installation.
 
 ## Installation
 
@@ -9,38 +9,87 @@ Brainstorm future features and improvements based on the current codebase. Inclu
 /plugin install brain-storm-plugin@devstefancho-claude-plugins
 ```
 
-## Trigger Keywords
+## Included Skills
 
-- "brainstorm", "feature ideas", "what could we build", "improvement ideas"
+### 1. `brain-storm`
+
+Use this skill to scan a codebase, propose grounded ideas, add ASCII wireframes, and save selected ideas into `brain-storm/` for later refinement.
+
+Typical triggers:
+
+- "brainstorm"
+- "feature ideas"
+- "what could we build"
+- "improvement ideas"
+- "clean up brainstorm notes"
+
+### 2. `ui-prototype-preview`
+
+Use this skill after a UI-focused brainstorm idea has been saved and you want a richer HTML mockup with a clear visual point of view.
+
+Typical triggers:
+
+- "prototype preview"
+- "generate HTML preview"
+- "turn this idea into a mockup"
+- "create a UI prototype"
+- "make the design stronger"
+
+### 3. `/ui-prototype-preview` command
+
+Use the slash command when you want a lightweight entry point for prototype generation. The skill remains the real implementation; the command is only a thin wrapper for more explicit invocation and better argument discoverability.
+
+Examples:
+- `/ui-prototype-preview running-portfolio-narrative-dashboard`
+- `/ui-prototype-preview running-portfolio-narrative-dashboard editorial dark`
+- `/ui-prototype-preview @brain-storm/running-portfolio-narrative-dashboard.md create 3 variants using our brand colors`
+
+The command should resolve the source idea, read or scaffold a design brief when needed, and then invoke the `ui-prototype-preview` workflow.
 
 ## How It Works
 
-1. **Codebase Scan** - Analyze project structure and existing ideas
-2. **Ideation** - Generate 3-5 ideas with complexity ratings and UI tags
-3. **Deduplication** - Check against existing ideas to avoid duplicates
-4. **Write** - Save selected ideas using templates (with wireframes for UI ideas)
-5. **Implementation Check** - Detect already-implemented ideas and remove with user confirmation
-6. **Report** - Output a summary of results
+1. **Codebase Scan** - Analyze the product structure and existing brainstorm notes.
+2. **Ideation** - Generate 3-5 ideas with complexity ratings and quick wireframes.
+3. **Deduplication** - Check existing brainstorm notes before writing new files.
+4. **Write** - Save selected ideas using a consistent markdown template.
+5. **Prototype Preview** - Turn selected UI ideas into standalone HTML files with a deliberate aesthetic direction.
+6. **Cleanup** - Detect already-implemented ideas and remove them after user confirmation.
+7. **Report** - Return concise next-step guidance for specs or preview revisions.
 
-## Directory Structure
+## Output Structure
 
-```
+```text
 brain-storm/
 ├── dashboard-analytics.md
 ├── auth/
 │   └── sso-login.md
-└── ui/
-    └── dark-mode-toggle.md
+├── design/
+│   └── dashboard-analytics-design.md
+└── previews/
+    ├── dashboard-analytics.html
+    └── dashboard-analytics-editorial-dark.html
 ```
 
-- Files are stored in `brain-storm/` with optional 1-depth subdirectories
-- Filenames use lowercase-with-hyphens format
+- Idea notes live in `brain-storm/` with optional one-level subdirectories.
+- Design briefs live in `brain-storm/design/`.
+- HTML previews live in `brain-storm/previews/`.
+- Filenames use lowercase-with-hyphens.
 
-## Differences from writing-specs-plugin
+## Design Brief Workflow
 
-| writing-specs | brain-storm |
-|---------------|-------------|
-| Specifies what **will** be built | Explores what **could** be built |
-| Structured requirements | Exploratory ideas |
-| No wireframes | ASCII wireframes for UI ideas |
-| Outdated content detection | Implementation completion detection |
+When a prototype needs multiple variants, exact colors, typography rules, or stronger brand constraints, use a design brief file rather than overloading the prompt.
+
+Recommended path:
+1. Save or auto-generate `brain-storm/design/{idea-name}-design.md`.
+2. Put variant count, aesthetic directions, color tokens, references, and anti-patterns in that file.
+3. Run `/ui-prototype-preview {idea title}`.
+4. Refine the design brief and rerun as needed.
+
+If no design brief exists and the request is complex, the skill should scaffold one automatically from the template and continue with a first-pass prototype.
+
+## Recommended Workflow
+
+1. Generate and save promising ideas with `brain-storm`.
+2. For UI-heavy ideas, create a mockup with `/ui-prototype-preview {idea title}`.
+3. If you need stronger control, create or edit `brain-storm/design/{idea-name}-design.md` with brand colors, typography notes, variant strategy, and constraints.
+4. Turn the validated idea into a buildable spec with `/writing-specs {idea title}`.

--- a/brain-storm-plugin/commands/ui-prototype-preview.md
+++ b/brain-storm-plugin/commands/ui-prototype-preview.md
@@ -1,0 +1,43 @@
+---
+argument-hint: "[idea-name or brainstorm-file] [optional direction or notes]"
+description: "Generate one or more UI prototype previews from a saved brainstorm idea, using a DESIGN.md brief when needed"
+---
+
+# UI Prototype Preview Command
+
+Use the `ui-prototype-preview` skill to turn a saved brainstorm idea into one or more standalone HTML prototypes. This command is intentionally a thin wrapper around the skill: it provides explicit slash-command UX and argument hints, while the skill owns the real generation logic.
+
+## Arguments
+
+- `$ARGUMENTS` - Idea name, brainstorm file reference, and any optional guidance such as a direction, design note, or revision request
+
+Examples:
+- `/ui-prototype-preview running-portfolio-narrative-dashboard`
+- `/ui-prototype-preview running-portfolio-narrative-dashboard editorial dark`
+- `/ui-prototype-preview @brain-storm/running-portfolio-narrative-dashboard.md create 3 variants using our brand system`
+
+## Command Behavior
+
+1. Resolve the source idea from `$ARGUMENTS`.
+2. Check for a relevant design brief in one of these places:
+   - A file explicitly referenced in `$ARGUMENTS`
+   - `brain-storm/design/{idea-name}-design.md`
+   - Another matching file in `brain-storm/design/`
+3. If the request is complex (multiple variants, brand colors, typography preferences, layout constraints, anti-patterns, or references) and no design brief exists:
+   - scaffold a design brief from `skills/ui-prototype-preview/templates/design-brief-template.md`
+   - save it under `brain-storm/design/{idea-name}-design.md`
+   - continue with a first prototype pass unless the user explicitly asked to review the brief first
+4. Generate the prototype HTML output under `brain-storm/previews/`.
+5. If variants are requested, create 2-3 materially different outputs rather than shallow palette swaps.
+6. Return a concise report including:
+   - source idea path
+   - design brief path
+   - output HTML path(s)
+   - variant count
+   - chosen aesthetic direction(s)
+
+## Quality Bar
+
+- Prefer a strong visual point of view over a generic dashboard layout.
+- If the user gives detailed brand constraints, apply them through the design brief rather than ignoring them.
+- If multiple variants are requested, make sure the variants differ in composition, typography, and memorable moment — not just color.

--- a/brain-storm-plugin/evals/evals.json
+++ b/brain-storm-plugin/evals/evals.json
@@ -1,70 +1,57 @@
 {
-  "skill_name": "brain-storm",
+  "skill_name": "brain-storm-plugin",
   "evals": [
     {
-      "id": 1,
-      "prompt": "이 프로젝트에서 앞으로 뭐 더 만들면 좋을지 브레인스톰 해줘",
-      "expected_output": "Codebase scan, 3-5 ideas presented, user selection prompt, idea files created in brain-storm/",
+      "id": "brainstorm-1",
+      "skill": "brain-storm",
+      "prompt": "Brainstorm what we should build next in this project.",
+      "expected_output": "Codebase scan, 3-5 grounded ideas, user selection prompt, idea files created in brain-storm/",
       "files": [],
       "expectations": [
         "Codebase scan performed before ideation",
-        "At least 3 ideas presented with title, description, and complexity",
+        "At least 3 ideas presented with title, description, complexity, and quick wireframe sketch",
         "User asked to select ideas via AskUserQuestion",
         "Selected ideas saved as markdown under brain-storm/",
-        "Each idea file follows the template structure (Summary, Motivation, Proposed Approach, Complexity, Open Questions)",
-        "Report output with Saved Ideas table"
-      ],
-      "assertions": [
-        {"id": "a1", "text": "At least 3 idea files created in brain-storm/ directory"},
-        {"id": "a2", "text": "Each idea file contains ## Summary section with 1-2 sentences"},
-        {"id": "a3", "text": "Each idea file contains ## Motivation section referencing actual codebase"},
-        {"id": "a4", "text": "Each idea file contains ## Proposed Approach with 3-7 bullet points"},
-        {"id": "a5", "text": "Each idea file contains ## Complexity with Low/Medium/High rating"},
-        {"id": "a6", "text": "Each idea file contains ## Open Questions section"},
-        {"id": "a7", "text": "Report file exists with Brain Storm Report table format"},
-        {"id": "a8", "text": "Filenames use lowercase-with-hyphens convention"}
+        "Final report includes next-step guidance for spec writing and HTML preview generation"
       ]
     },
     {
-      "id": 2,
-      "prompt": "대시보드 UI를 개선할 아이디어 좀 내줘. 차트랑 필터 기능 관련으로",
-      "expected_output": "UI-focused ideas with [UI] tag, wireframe included in saved files",
+      "id": "brainstorm-2",
+      "skill": "brain-storm",
+      "prompt": "Clean up brainstorm notes and remove anything already implemented.",
+      "expected_output": "Existing brainstorm files scanned, implementation check performed, confirmation requested before deletion",
       "files": [],
       "expectations": [
-        "Ideas tagged with [UI] for UI-related concepts",
-        "Saved idea files include Wireframe section",
-        "Wireframe uses ASCII art with box-drawing characters",
-        "Wireframe is at least 10 lines",
-        "Non-UI ideas omit Wireframe section entirely"
-      ],
-      "assertions": [
-        {"id": "b1", "text": "At least 2 idea files created for UI improvement ideas"},
-        {"id": "b2", "text": "Each idea file contains ## Wireframe section"},
-        {"id": "b3", "text": "Wireframe uses ASCII box-drawing characters"},
-        {"id": "b4", "text": "Wireframe is at least 10 lines long"},
-        {"id": "b5", "text": "Wireframe includes interactive elements like [ Button ] or [ input ]"},
-        {"id": "b6", "text": "Ideas are specifically about dashboard, charts, or filters"},
-        {"id": "b7", "text": "Report file exists with proper format"}
+        "All brainstorm files are listed and read",
+        "Implementation evidence is gathered from the source code",
+        "User confirmation is requested before deletion",
+        "Final report includes cleanup status for reviewed ideas"
       ]
     },
     {
-      "id": 3,
-      "prompt": "브레인스톰 아이디어 정리해줘. 이미 구현된 거 있으면 삭제하고",
-      "expected_output": "Existing brain-storm files scanned, implementation check via source code grep, user confirmation before deletion",
+      "id": "prototype-1",
+      "skill": "ui-prototype-preview",
+      "prompt": "Create an HTML prototype preview for the saved dashboard analytics idea.",
+      "expected_output": "Saved brainstorm idea located, HTML preview generated under brain-storm/previews/, concise report returned",
       "files": [],
       "expectations": [
-        "All brain-storm/**/*.md files listed and read",
-        "Keywords extracted from each idea and grepped in source code",
-        "Implemented ideas identified and presented to user",
-        "User confirmation requested before any deletion",
-        "Report includes Implementation Check section"
-      ],
-      "assertions": [
-        {"id": "c1", "text": "git-worktree-management.md correctly identified as implemented and deleted"},
-        {"id": "c2", "text": "ai-code-review.md correctly identified as implemented and deleted"},
-        {"id": "c3", "text": "plugin-dependency-graph.md correctly identified as NOT implemented and kept"},
-        {"id": "c4", "text": "Report includes Implementation Check section with correct statuses"},
-        {"id": "c5", "text": "Report file exists with proper format"}
+        "A saved brainstorm idea is located before HTML generation",
+        "Output file is written to brain-storm/previews/{idea-name}.html",
+        "Generated HTML is standalone with embedded CSS",
+        "Final report includes source idea path and output HTML path"
+      ]
+    },
+    {
+      "id": "prototype-2",
+      "skill": "ui-prototype-preview",
+      "prompt": "Turn this UI brainstorm into three variants using our brand colors and create a design brief if one does not exist.",
+      "expected_output": "Design brief scaffolded or read, multiple variants generated, final report includes variant files and design brief path",
+      "files": [],
+      "expectations": [
+        "A design brief is created or read before rendering when the request is constraint-heavy",
+        "2-3 meaningful variants are generated rather than shallow palette swaps",
+        "Variant filenames are distinct",
+        "Final report includes design brief path and variant count"
       ]
     }
   ]

--- a/brain-storm-plugin/skills/brain-storm/SKILL.md
+++ b/brain-storm-plugin/skills/brain-storm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brain-storm
-description: Brainstorm future features and improvements based on the current codebase. This is the ideation step BEFORE writing specs (/writing-specs). Use when user asks to brainstorm ideas, generate feature ideas, explore improvements, or mentions 브레인스톰, 아이디어, 기능 제안, 개선 아이디어, 뭐 만들까, 앞으로 뭐 하지. Also trigger for cleanup requests like 브레인스톰 정리, 구현된 아이디어 정리. Proactively trigger when the user wants creative exploration of what COULD be built.
+description: Brainstorm future features and improvements based on the current codebase. This is the ideation step before writing specs. Use when the user asks to brainstorm ideas, generate feature ideas, explore improvements, review future opportunities, or clean up outdated brainstorm notes.
 allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion
 context: fork
 agent: general-purpose
@@ -8,74 +8,72 @@ agent: general-purpose
 
 # Brain Storm
 
-`/writing-specs`로 스펙을 작성하기 전 단계. 사용자가 전달한 아이디어를 바탕으로 추가적이고 구체적인 아이디어를 도출한다. 아이디어마다 대략적인 wireframe을 포함하여 구현 방향을 시각화하고, 선정된 아이디어를 `brain-storm/` 디렉토리에 마크다운으로 저장한다.
+Use this skill before `/writing-specs` to explore what could be built next. The skill scans the codebase, proposes grounded ideas, adds lightweight wireframes, and saves selected ideas into the `brain-storm/` directory for later refinement.
 
 ## Two Modes
 
-이 스킬은 두 가지 모드로 동작한다. 사용자 요청에 따라 적절한 모드를 선택한다.
+This skill supports two modes. Pick the mode that matches the user's request.
 
-- **Brainstorm Mode** (기본): 아이디어 생성 & 저장. "브레인스톰 해줘", "아이디어 내줘" 등
-- **Cleanup Mode**: 이미 구현된 아이디어 감지 & 삭제. "브레인스톰 정리", "구현된 거 삭제" 등
+- **Brainstorm Mode**: Generate, compare, and save new ideas.
+- **Cleanup Mode**: Review existing brainstorm notes, detect already-implemented ideas, and remove them after user confirmation.
 
 ## Principles
 
-1. **Explore before proposing** - 코드베이스를 먼저 파악한 뒤 아이디어를 제안한다. 실제 코드에 기반한 아이디어가 훨씬 유용하다.
-2. **Diverge then converge** - 먼저 여러 아이디어를 자유롭게 생성(최소 3개)한 뒤, 사용자가 선택한다.
-3. **One idea = one file** - 각 아이디어는 별도 파일로 관리한다. 내용이 매우 적은 경우(bullet 3개 이하)에만 합칠 수 있다.
-4. **Always wireframe** - 모든 아이디어에 대략적인 wireframe을 포함한다. 화면 관련 아이디어는 상세한 UI wireframe을, 백엔드/인프라 아이디어는 아키텍처 다이어그램이나 데이터 플로우를 ASCII로 그린다.
-5. **Prune the implemented** - Cleanup Mode에서 기존 아이디어가 이미 구현되었는지 확인하고 정리한다.
+1. **Explore before proposing** - Understand the codebase before suggesting ideas.
+2. **Diverge then converge** - Generate multiple strong options before asking the user to choose.
+3. **One idea = one file** - Store each meaningful idea as its own markdown file.
+4. **Always visualize** - Every saved idea should include a simple ASCII wireframe or system sketch so the implementation direction is easier to discuss.
+5. **Prune the implemented** - Cleanup mode should remove stale brainstorm notes only after evidence-based verification and user approval.
 
 ## Directory Rules
 
-- Ideas live in `brain-storm/` at the project root
-- File format: `brain-storm/{name}.md` or `brain-storm/{subdir}/{name}.md`
-- Only 1-depth subdirectories allowed (e.g., `brain-storm/auth/sso-login.md` OK, `brain-storm/auth/v2/sso.md` NOT OK)
-- Filenames: lowercase-with-hyphens (e.g., `dark-mode-toggle.md`)
-- Create subdirectories only when user requests grouping or 5+ ideas share a domain
+- Ideas live in `brain-storm/` at the project root.
+- File format: `brain-storm/{name}.md` or `brain-storm/{subdir}/{name}.md`.
+- Only one directory level is allowed under `brain-storm/`.
+- Filenames must use lowercase-with-hyphens.
+- Create subdirectories only when the user requests grouping or when five or more ideas share the same domain.
 
 ---
 
 ## Brainstorm Mode
 
-### Step 1: Scan & Ideate
+### Step 1: Scan and Ideate
 
-First understand the codebase, then generate ideas:
-
-1. Run `Glob` on key directories (`src/**`, `app/**`, `pages/**`, `components/**`, `lib/**`, etc.) to map project structure
-2. Run `Glob brain-storm/**/*.md` to list existing brainstorm ideas
-3. Read `package.json`, `README.md`, or equivalent to understand tech stack
-4. Generate 3-5 ideas based on the scan. For each, present:
-   - **Title** (as H3)
+1. Run `Glob` on important project directories such as `src/**`, `app/**`, `pages/**`, `components/**`, and `lib/**` to understand the structure.
+2. Run `Glob brain-storm/**/*.md` to inspect existing brainstorm notes.
+3. Read `package.json`, `README.md`, and any obvious entry-point files to understand the product and stack.
+4. Generate 3-5 ideas based on the scan. For each idea, present:
+   - **Title**
    - **Description**: 1-2 sentences
    - **Complexity**: Low / Medium / High
    - **Quick wireframe sketch**: 3-5 lines of ASCII to give a visual sense of the idea
-5. Ask the user: "어떤 아이디어를 저장할까요? 번호로 선택하세요 (여러 개 가능). 수정하거나 새로운 아이디어를 추가할 수도 있습니다."
+5. Ask the user which ideas to save.
 
-Ideas should be grounded in the actual codebase (reference specific files/patterns), actionable, and varied in scope.
+Ideas must be grounded in the actual codebase, actionable, and varied in scope.
 
-### Step 2: Deduplicate & Write
+### Step 2: Deduplicate and Write
 
 For each selected idea:
 
-1. Extract 3-5 key nouns from the title/description
-2. Run `Grep` across `brain-storm/**/*.md` for those keywords
-3. If duplicate found, ask: "이미 유사한 아이디어가 존재합니다: `{path}`. 업데이트할까요, 새로 생성할까요, 건너뛸까요?"
-4. Read the idea template: [templates/idea-template.md](templates/idea-template.md)
-5. Read the wireframe guide: [templates/wireframe-guide.md](templates/wireframe-guide.md)
-6. Fill in all sections:
+1. Extract 3-5 key nouns from the title and description.
+2. Run `Grep` across `brain-storm/**/*.md` for those keywords.
+3. If a duplicate or near-duplicate exists, ask whether to update the existing file, create a new file, or skip it.
+4. Read the idea template at `templates/idea-template.md`.
+5. Read the wireframe guide at `templates/wireframe-guide.md`.
+6. Fill every section:
    - **Summary**: 1-2 sentences
-   - **Motivation**: 2-4 sentences referencing specific codebase parts
-   - **Proposed Approach**: 3-7 bullet points (no code snippets)
-   - **Wireframe**: ASCII art in fenced code block, minimum 10 lines. For UI ideas: screen layout with interactive elements. For non-UI ideas: architecture diagram, data flow, or system interaction diagram.
-   - **Complexity**: Low/Medium/High with 1-sentence justification
+   - **Motivation**: 2-4 sentences referencing specific codebase areas
+   - **Proposed Approach**: 3-7 bullet points without code snippets
+   - **Wireframe**: ASCII art in a fenced code block, at least 10 lines
+   - **Complexity**: Low / Medium / High with a one-sentence reason
    - **Open Questions**: 1-3 bullets
-7. Write to the appropriate path under `brain-storm/`
+7. Write the completed idea file under `brain-storm/`.
 
 ### Step 3: Report
 
-After writing all idea files, output a summary report directly (no separate file needed):
+After writing all idea files, include this report in the final response:
 
-```
+```markdown
 ## Brain Storm Report
 
 | Field | Value |
@@ -90,39 +88,30 @@ After writing all idea files, output a summary report directly (no separate file
 | `{path}` | {title} | {complexity} |
 
 ### Next Steps
-- 스펙으로 발전시키려면: /writing-specs {idea title}
+- Refine an idea into a spec: `/writing-specs {idea title}`
+- Generate a UI prototype preview for a UI-focused idea: `/ui-prototype-preview {idea title}`
 ```
 
-The report is part of the final response message, not a separate file. This ensures it always gets delivered.
+The report must be part of the final response, not a separate file.
 
 ---
 
 ## Cleanup Mode
 
-Triggered by: "브레인스톰 정리", "구현된 아이디어 정리", "clean up brainstorm"
+Triggered by requests such as "clean up brainstorm notes" or "remove ideas that are already implemented".
 
 ### Step 1: Detect Implemented Ideas
 
-1. Run `Glob brain-storm/**/*.md` to list all idea files
+1. Run `Glob brain-storm/**/*.md` to list all idea files.
 2. For each idea:
-   a. Read the file, extract title + summary
-   b. Extract 3-5 implementation-indicator keywords (component names, function names, route paths, API endpoints)
-   c. Run `Grep` for those keywords in source code (exclude `brain-storm/`, `specs/`, `node_modules/`, `.git/`)
-   d. Mark as **implemented** if 3+ keywords match in source code AND the code actually implements the described functionality (not just naming coincidence or TODOs)
+   a. Read the file and extract the title and summary.
+   b. Extract 3-5 implementation-indicator keywords such as component names, function names, routes, or API endpoints.
+   c. Run `Grep` for those keywords in the source code while excluding `brain-storm/`, `specs/`, `node_modules/`, and `.git/`.
+   d. Mark the idea as implemented only if multiple matches clearly represent the described functionality rather than TODOs or naming coincidence.
 
-### Step 2: Confirm & Delete
+### Step 2: Confirm and Delete
 
-1. Present findings to user: "다음 아이디어가 이미 구현된 것으로 보입니다:"
-   - For each implemented idea: show file path, matched evidence (which files/functions matched)
-2. Ask: "삭제할까요? (전체/선택적/취소)"
-3. Delete only after user confirmation
-4. Report results:
-
-```
-## Cleanup Report
-
-| Idea | Status | Evidence |
-|------|--------|----------|
-| `{path}` | Implemented (deleted) | {matched files} |
-| `{path}` | Not implemented (kept) | - |
-```
+1. Present the implemented candidates with supporting evidence.
+2. Ask the user whether to delete all, delete selected ideas, or cancel.
+3. Delete files only after explicit confirmation.
+4. Report the result with status and evidence for each reviewed idea.

--- a/brain-storm-plugin/skills/brain-storm/templates/report-template.md
+++ b/brain-storm-plugin/skills/brain-storm/templates/report-template.md
@@ -18,4 +18,5 @@
 - {idea path} - {Implemented (deleted) / Implemented (kept) / Not yet implemented}
 
 ### Next Steps
-- {1-2 actionable items}
+- Refine a saved idea into a spec with `/writing-specs {idea title}`
+- Generate an HTML preview for a UI-focused idea with `/ui-prototype-preview {idea title}`

--- a/brain-storm-plugin/skills/ui-prototype-preview/SKILL.md
+++ b/brain-storm-plugin/skills/ui-prototype-preview/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: ui-prototype-preview
+description: Generate a distinctive standalone HTML preview from a saved UI brainstorm idea. Use when the user wants to visualize a brainstorm idea as a concrete mockup, prototype, preview, landing page, dashboard, or product screen with strong design quality.
+allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion
+context: fork
+agent: general-purpose
+---
+
+# UI Prototype Preview
+
+Generate a self-contained HTML prototype from a saved brainstorm idea. This skill should produce a visually distinctive concept, not a generic AI-looking dashboard. Use it after `brain-storm` when a UI-focused idea needs a stronger visual artifact before specification or implementation.
+
+## Principles
+
+1. **Start from saved intent** - Prefer an existing file in `brain-storm/` instead of inventing a product direction from scratch.
+2. **Concept first, code second** - Commit to a clear aesthetic direction before writing any HTML.
+3. **Design brief over overloaded arguments** - Prefer a reusable `DESIGN.md` file when there are many constraints, brand tokens, or variant requests.
+4. **Prototype, do not under-design** - The goal is not production code, but the result must still feel deliberate, polished, and memorable.
+5. **One standout idea** - Every preview should have a single memorable visual or interaction moment that defines the concept.
+6. **Avoid generic AI aesthetics** - Do not default to bland SaaS cards, overused purple-on-white palettes, or interchangeable layouts.
+7. **Traceability** - Report which brainstorm file the preview came from, what design direction you chose, which design brief you used, and where the HTML was saved.
+
+## Output Rules
+
+- Save previews to `brain-storm/previews/{idea-name}.html`.
+- For multi-variant runs, save files to `brain-storm/previews/{idea-name}-{variant-slug}.html`.
+- Save design briefs to `brain-storm/design/{idea-name}-design.md` unless the user provides a different path.
+- Use lowercase-with-hyphens for filenames.
+- Create `brain-storm/previews/` and `brain-storm/design/` if they do not exist.
+- The HTML must be standalone with embedded `<style>` and no build step.
+- Default to responsive desktop-first layouts unless the brainstorm idea clearly targets mobile.
+- Include semantic structure and accessible text labels.
+- Prefer locally safe font stacks or imported web fonts only when the environment clearly supports them.
+
+## When to Use a Design Brief
+
+Use a `DESIGN.md`-style file whenever the user wants any of the following:
+- 2 or more variants
+- Exact brand colors or theme tokens
+- Font or typography preferences
+- A defined design system or UI kit influence
+- Explicit anti-patterns or forbidden aesthetics
+- Device/layout preferences such as mobile-first, landing-page-first, or dashboard-first
+- Reference links, screenshots, or brand keywords to steer the direction
+
+If the user only gives a simple request, you may proceed without a design brief. But if the request becomes constraint-heavy, create or read a design brief instead of stuffing everything into one command-like prompt.
+
+## Design Brief Workflow
+
+### Step 0: Resolve the Design Brief
+
+1. Search for a relevant design brief in this order:
+   - User-provided path
+   - `brain-storm/design/{idea-name}-design.md`
+   - Other matching `brain-storm/design/**/*.md` files
+2. If a suitable design brief exists, read it and apply it.
+3. If no design brief exists and the request is complex, auto-generate one from `templates/design-brief-template.md`.
+4. Fill the generated brief with sensible defaults derived from the brainstorm idea.
+5. Save the generated brief under `brain-storm/design/{idea-name}-design.md`.
+6. Tell the user you created the design brief and continue with the first prototype pass unless the user asked to review the brief before generation.
+
+## Design Quality Standard
+
+Before writing HTML, define all of the following:
+
+### 1. Product Context
+- What job is this screen doing?
+- Who is it for?
+- What action or feeling should the screen drive?
+
+### 2. Aesthetic Direction
+Choose one bold direction and name it explicitly in your working notes and final report. Examples:
+- Editorial performance journal
+- Premium athlete brand system
+- Gritty marathon training console
+- Race-day command center
+- Minimal training notebook
+- Luxury progress portfolio
+- Playful quantified-self scrapbook
+
+### 3. Visual System
+Decide intentionally:
+- Typography pairing and why it fits
+- Color palette and contrast structure
+- Layout composition (symmetrical, editorial, layered, asymmetrical, dense, minimal)
+- Surface treatment (glass, paper, grain, sharp borders, soft depth, flat blocks, etc.)
+- Motion hints or micro-interactions, even if only described in CSS states
+
+### 4. Memorable Moment
+Add one signature move that makes the preview feel designed, such as:
+- Hero typography treatment
+- Dramatic progress rail
+- Editorial split layout
+- Layered card stack
+- Full-bleed metric strip
+- Race-path timeline
+- Textured story panel
+
+## Anti-Patterns
+
+Do not ship a preview that looks like a default template. Specifically avoid:
+- Inter + generic SaaS card layout by default
+- Safe purple-blue gradients unless the product context truly calls for them
+- Evenly spaced identical cards with no hierarchy
+- Placeholder UI with no point of view
+- Decorative effects with no relationship to the product story
+
+If your first instinct looks interchangeable with a random startup admin dashboard, stop and choose a stronger direction.
+
+## Workflow
+
+### Step 1: Find the Source Idea
+
+1. Run `Glob brain-storm/**/*.md` to find saved ideas.
+2. If the user did not specify a file or the match is ambiguous, ask which idea to use.
+3. Read the selected brainstorm file carefully.
+4. Extract the title, summary, proposed approach, wireframe, and open questions.
+
+### Step 2: Build a Design Brief Before Coding
+
+Using the brainstorm file plus any resolved `DESIGN.md`, write a concise internal brief:
+- Primary user goal
+- Key sections and layout hierarchy
+- Core interactive elements
+- States worth showing in the preview
+- Aesthetic direction
+- Visual system choices
+- Memorable moment
+- Variant strategy (if applicable)
+- Any unresolved assumptions that need to be called out
+
+If the brainstorm note is not actually UI-focused, tell the user and ask whether to continue with a conceptual mockup or stop.
+
+### Step 3: Parse Variant Instructions
+
+1. If the design brief or user request asks for multiple variants, create 2-3 distinct directions.
+2. Each variant must differ meaningfully in at least two of the following:
+   - aesthetic direction
+   - typography system
+   - palette
+   - layout composition
+   - memorable moment
+3. Do not create shallow palette swaps.
+4. Name variants clearly, for example `editorial-dark`, `premium-athlete`, or `race-console`.
+
+### Step 4: Generate the HTML Preview
+
+1. Read `templates/prototype-template.html`.
+2. Replace placeholders with a concept-specific implementation:
+   - `{{TITLE}}` - Page title based on the idea
+   - `{{FONT_PRELOADS}}` - Optional font imports or leave blank
+   - `{{DESIGN_TOKENS}}` - CSS variables for palette, typography, radius, shadows, spacing, and textures
+   - `{{BASE_STYLES}}` - Layout and reusable component styling for the chosen concept
+   - `{{MOTION_STYLES}}` - Hover, focus, reveal, or transition rules
+   - `{{BODY_CLASS}}` - Theme or concept class name
+   - `{{BODY}}` - The actual semantic HTML for the screen
+3. Build a screen that demonstrates hierarchy, intentional typography, and at least one standout visual moment.
+4. Use sample content that feels product-specific rather than generic lorem ipsum.
+5. Save each result to `brain-storm/previews/{idea-name}.html` or variant-specific filenames.
+6. If the environment supports it, optionally open the file with a local browser command.
+
+### Step 5: Self-Critique Before Finishing
+
+Before finalizing, check:
+- Does this look specific to the product idea?
+- Is the typography intentional rather than default?
+- Is there a clear visual hierarchy?
+- Is there one memorable moment?
+- Would a designer recognize an aesthetic point of view?
+- Did you apply the design brief rather than merely mention it?
+- Did you avoid generic AI-dashboard styling?
+
+If the answer to multiple questions is no, revise the preview before returning it.
+
+### Step 6: Report
+
+Return a concise report in the final response:
+
+```markdown
+## UI Prototype Preview Report
+
+| Field | Value |
+|-------|-------|
+| Source Idea | `brain-storm/{idea-file}.md` |
+| Design Brief | `brain-storm/design/{idea-name}-design.md` or `{user path}` |
+| Output HTML | `brain-storm/previews/{idea-name}.html` or `{variant files}` |
+| Variant Count | {1 / 2 / 3} |
+| Aesthetic Direction | {chosen concept or concepts} |
+| Memorable Moment | {signature visual move} |
+| Key Interactions | {buttons / filters / forms / navigation} |
+
+### Notes
+- {important assumptions or follow-up opportunities}
+
+### Next Steps
+- Refine the design brief and rerun the prototype if stronger brand constraints are needed
+- Convert the idea into a buildable spec: `/writing-specs {idea title}`
+```

--- a/brain-storm-plugin/skills/ui-prototype-preview/examples/running-portfolio-design.sample.md
+++ b/brain-storm-plugin/skills/ui-prototype-preview/examples/running-portfolio-design.sample.md
@@ -1,0 +1,88 @@
+# Example Design Brief: Running Portfolio Narrative Dashboard
+
+## Purpose
+- Explore how a personal running portfolio can feel like a public-facing athlete brand instead of a generic training dashboard.
+- Validate which visual direction best supports storytelling, motivation, and shareability.
+
+## Variant Plan
+- variant_count: 3
+- variant_strategy:
+  - editorial-dark
+  - athlete-brand-light
+  - race-console-grit
+- Each variant should feel materially different in palette, typography, composition, and memorable moment.
+
+## Brand / Product Keywords
+- disciplined
+- cinematic
+- progress as story
+- public proof
+- marathon identity
+
+## Desired Aesthetic Direction
+- Primary direction: premium athlete portfolio
+- Optional alternate directions:
+  - editorial sports journal
+  - tactical race command center
+
+## Color System
+- primary: #ff5a36
+- secondary: #0f172a
+- accent: #f4c95d
+- background: dark by default, but allow one bright premium variant
+- text: high contrast, editorial-feeling
+- Avoid these colors if relevant: default SaaS purple-blue gradients
+
+## Typography
+- display font mood: condensed athletic headlines or strong editorial serif
+- body font mood: refined, readable, confident
+- typography notes: headlines should feel campaign-like rather than app-like
+
+## Layout & Device Preferences
+- device_priority: desktop-first
+- preferred layout type: narrative landing page / portfolio editorial layout
+- must-have sections:
+  - hero statement
+  - race target or progress tracker
+  - milestone story section
+  - recent training evidence
+  - public proof / achievements
+- avoid layout patterns:
+  - generic left-sidebar admin shell
+  - evenly repeated cards as the only hierarchy
+
+## Interaction & Motion
+- interaction tone: premium, calm, deliberate
+- motion level: subtle
+- must-have interactions:
+  - strong primary CTA
+  - hover feedback on story modules
+  - one highlighted progress mechanic
+
+## Design System Constraints
+- border radius style: medium to strong, but intentional
+- density: comfortable
+- surface treatment: premium depth or light texture where appropriate
+- component cues to include:
+  - statement hero
+  - layered section rhythm
+  - narrative copy mixed with metrics
+- component cues to avoid:
+  - generic dashboard chrome
+  - overused frosted glass on every panel
+
+## References
+- reference links:
+  - https://www.nike.com/running
+  - https://www.strava.com/
+- products or brands to echo:
+  - Nike Running campaign pages
+  - premium sports editorial layouts
+- products or styles to avoid:
+  - default B2B admin dashboards
+
+## Notes for the Agent
+- Variant 1 should feel cinematic and dark.
+- Variant 2 should feel premium, bright, and portfolio-like.
+- Variant 3 should feel tactical and race-focused with grit.
+- Make each direction recognizable at a glance.

--- a/brain-storm-plugin/skills/ui-prototype-preview/templates/design-brief-template.md
+++ b/brain-storm-plugin/skills/ui-prototype-preview/templates/design-brief-template.md
@@ -1,0 +1,73 @@
+# Design Brief: {idea title}
+
+## Purpose
+- What should this prototype help decide, communicate, or validate?
+- Who is the primary audience?
+
+## Variant Plan
+- variant_count: 1
+- variant_strategy:
+  - single-direction
+- If creating multiple variants, explain how they should differ.
+
+## Brand / Product Keywords
+- keyword_1
+- keyword_2
+- keyword_3
+
+## Desired Aesthetic Direction
+- Primary direction:
+- Optional alternate directions:
+  -
+  -
+
+## Color System
+- primary:
+- secondary:
+- accent:
+- background:
+- text:
+- Avoid these colors if relevant:
+
+## Typography
+- display font mood:
+- body font mood:
+- typography notes:
+
+## Layout & Device Preferences
+- device_priority: desktop-first
+- preferred layout type:
+- must-have sections:
+  -
+  -
+  -
+- avoid layout patterns:
+  -
+
+## Interaction & Motion
+- interaction tone:
+- motion level: subtle
+- must-have interactions:
+  -
+
+## Design System Constraints
+- border radius style:
+- density: comfortable
+- surface treatment:
+- component cues to include:
+  -
+- component cues to avoid:
+  -
+
+## References
+- reference links:
+  -
+- products or brands to echo:
+  -
+- products or styles to avoid:
+  -
+
+## Notes for the Agent
+- If this file is auto-generated, replace placeholders with product-specific assumptions before rendering.
+- Prefer strong point of view over neutral dashboard styling.
+- Variants should be materially different, not simple color swaps.

--- a/brain-storm-plugin/skills/ui-prototype-preview/templates/prototype-template.html
+++ b/brain-storm-plugin/skills/ui-prototype-preview/templates/prototype-template.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{TITLE}}</title>
+    {{FONT_PRELOADS}}
+    <style>
+      :root {
+        {{DESIGN_TOKENS}}
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html {
+        scroll-behavior: smooth;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+      }
+
+      img {
+        max-width: 100%;
+        display: block;
+      }
+
+      button,
+      input,
+      select,
+      textarea {
+        font: inherit;
+      }
+
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      {{BASE_STYLES}}
+
+      {{MOTION_STYLES}}
+    </style>
+  </head>
+  <body class="{{BODY_CLASS}}">
+    {{BODY}}
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- expand `brain-storm-plugin` so `ui-prototype-preview` supports DESIGN.md-driven prototype generation
- add a thin-wrapper `/ui-prototype-preview` command, sample design brief, and reusable design brief template
- update plugin docs, evals, and metadata to support variant-based HTML prototype workflows

## Test plan
- [x] Generated a running-portfolio design brief under `brain-storm/design/`
- [x] Rendered 3 materially different running-portfolio prototype variants from the same idea
- [x] Verified the generated comparison page in the browser and captured screenshots

## Notes
- `ui-prototype-preview` remains the core skill implementation
- `/ui-prototype-preview` is documented as a thin wrapper for explicit invocation and argument discoverability