### PR TITLE
Fix create-team execution context

### DIFF
--- a/agent-team-plugin/.claude-plugin/plugin.json
+++ b/agent-team-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-team-plugin",
   "description": "Agent team management - create, expand, and cleanup teams for worktree sessions",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": {
     "name": "Stefan Cho"
   }

--- a/agent-team-plugin/.claude-plugin/plugin.json
+++ b/agent-team-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-team-plugin",
   "description": "Agent team management - create, expand, and cleanup teams for worktree sessions",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": {
     "name": "Stefan Cho"
   }

--- a/agent-team-plugin/README.md
+++ b/agent-team-plugin/README.md
@@ -72,6 +72,10 @@ Goal → planner(spec) → TaskCreate → team-lead review → implementer(code)
 
 ## Configuration
 
+### Skill model and effort
+
+The `create team` skill is configured to run with `model: sonnet` and `effort: high` for more reliable team orchestration and fallback handling.
+
 ### 1M Context for Teammates
 
 Teammates use the standard Opus model by default. To enable 1M context:

--- a/agent-team-plugin/README.md
+++ b/agent-team-plugin/README.md
@@ -12,6 +12,7 @@ Create, expand, and manage agent teams for worktree sessions. Orchestrates multi
 ## Prerequisites
 
 - Must start with `claude -w` (worktree session)
+- Run `create team` from the active team-lead session, not from a forked helper agent
 - `writing-specs-plugin` recommended for planner's spec writing (optional)
 
 ## Commands

--- a/agent-team-plugin/skills/create-team/SKILL.md
+++ b/agent-team-plugin/skills/create-team/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: create-team
 description: Create an agent team with planner and implementer teammates for spec-driven development. Use when user says "create team", "팀 생성", "팀 만들어줘", "agent team", or wants to set up a planner+implementer workflow in a worktree session.
+model: sonnet
+effort: high
 allowed-tools: Bash, Agent, SendMessage, TeamCreate, TaskCreate, TaskList, TaskUpdate, Read, AskUserQuestion
 ---
 

--- a/agent-team-plugin/skills/create-team/SKILL.md
+++ b/agent-team-plugin/skills/create-team/SKILL.md
@@ -2,8 +2,6 @@
 name: create-team
 description: Create an agent team with planner and implementer teammates for spec-driven development. Use when user says "create team", "팀 생성", "팀 만들어줘", "agent team", or wants to set up a planner+implementer workflow in a worktree session.
 allowed-tools: Bash, Agent, SendMessage, TeamCreate, TaskCreate, TaskList, TaskUpdate, Read, AskUserQuestion
-context: fork
-agent: general-purpose
 ---
 
 # Create Team
@@ -56,12 +54,13 @@ Teammate colors are auto-assigned from a hardcoded palette and cannot be configu
 
 ## Fallback
 
-If Agent tool + `team_name` parameter fails with internal error (known issue anthropics/claude-code#40270):
-1. Inform the user about the issue
+If teammate spawning via the Agent tool fails with `team_name` or another internal error in the current session (known issue anthropics/claude-code#40270):
+1. Inform the user that team creation succeeded but teammate spawning failed in the current execution context
 2. Suggest spawning teammates manually:
    - Open separate terminal windows
    - Run `claude` in each with the planner/implementer prompts
    - Use SendMessage for coordination
+3. Do not claim the Agent tool is globally unavailable unless the session explicitly shows that tool is missing
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- remove forked execution context from the create-team skill so it runs in the active team-lead session
- clarify fallback messaging so it does not claim the Agent tool is globally unavailable
- document the active-session requirement and bump the plugin patch version

## Testing
- reviewed git diff for agent-team-plugin files
- verified create-team skill frontmatter no longer uses forked context