### PR TITLE
Clarify 1M Opus setup guidance

### DIFF
--- a/agent-team-plugin/.claude-plugin/plugin.json
+++ b/agent-team-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-team-plugin",
   "description": "Agent team management - create, expand, and cleanup teams for worktree sessions",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": {
     "name": "Stefan Cho"
   }

--- a/agent-team-plugin/README.md
+++ b/agent-team-plugin/README.md
@@ -78,13 +78,23 @@ The `create team` skill is configured to run with `model: sonnet` and `effort: h
 
 ### 1M Context for Teammates
 
-Teammates use the standard Opus model by default. To enable 1M context:
+Teammates use the standard Opus model by default.
+
+For a single session, prefer switching explicitly with:
+
+```bash
+/model opus[1m]
+```
+
+To make 1M context the default for Opus teammates before starting Claude Code, you can set:
 
 ```bash
 export ANTHROPIC_DEFAULT_OPUS_MODEL='claude-opus-4-6[1m]'
 ```
 
-Add to `.zshrc` for permanent use.
+Use plain ASCII quotes (`'`), not smart quotes (`‘’`), when copying that command into your shell.
+
+Add the export to `.zshrc` only if you want this behavior permanently.
 
 ### Auto-Setup
 

--- a/agent-team-plugin/skills/create-team/SKILL.md
+++ b/agent-team-plugin/skills/create-team/SKILL.md
@@ -72,4 +72,4 @@ If teammate spawning via the Agent tool fails with `team_name` or another intern
 - `/loop` is session-scoped and expires after 7 days
 - Teammate colors are auto-assigned from hardcoded palette (red, blue, green, yellow...) — not configurable
 - All communication flows through team-lead (planner <-> implementer direct messaging disabled by prompt rules)
-- Teammate model defaults to standard Opus (no 1M context). To use 1M context, set env var before starting: `export ANTHROPIC_DEFAULT_OPUS_MODEL='claude-opus-4-6[1m]'`
+- Teammate model defaults to standard Opus (no 1M context). For one-off use, prefer `/model opus[1m]`. To make 1M context the default before starting Claude Code, set `export ANTHROPIC_DEFAULT_OPUS_MODEL='claude-opus-4-6[1m]'` using plain ASCII quotes (`'`), not smart quotes (`‘’`).


### PR DESCRIPTION
## Summary
- prefer `/model opus[1m]` for one-off teammate sessions
- keep the env var example for persistent configuration
- warn users to use plain ASCII quotes instead of smart quotes when copying the export command

## Testing
- reviewed the README and create-team skill diff
- verified the new branch contains only the post-merge guidance change