### PR TITLE
Remove 1M teammate guidance

### DIFF
--- a/agent-team-plugin/.claude-plugin/plugin.json
+++ b/agent-team-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-team-plugin",
   "description": "Agent team management - create, expand, and cleanup teams for worktree sessions",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "author": {
     "name": "Stefan Cho"
   }

--- a/agent-team-plugin/README.md
+++ b/agent-team-plugin/README.md
@@ -76,25 +76,9 @@ Goal → planner(spec) → TaskCreate → team-lead review → implementer(code)
 
 The `create team` skill is configured to run with `model: sonnet` and `effort: high` for more reliable team orchestration and fallback handling.
 
-### 1M Context for Teammates
+### Teammate model
 
 Teammates use the standard Opus model by default.
-
-For a single session, prefer switching explicitly with:
-
-```bash
-/model opus[1m]
-```
-
-To make 1M context the default for Opus teammates before starting Claude Code, you can set:
-
-```bash
-export ANTHROPIC_DEFAULT_OPUS_MODEL='claude-opus-4-6[1m]'
-```
-
-Use plain ASCII quotes (`'`), not smart quotes (`‘’`), when copying that command into your shell.
-
-Add the export to `.zshrc` only if you want this behavior permanently.
 
 ### Auto-Setup
 

--- a/agent-team-plugin/skills/create-team/SKILL.md
+++ b/agent-team-plugin/skills/create-team/SKILL.md
@@ -72,4 +72,4 @@ If teammate spawning via the Agent tool fails with `team_name` or another intern
 - `/loop` is session-scoped and expires after 7 days
 - Teammate colors are auto-assigned from hardcoded palette (red, blue, green, yellow...) — not configurable
 - All communication flows through team-lead (planner <-> implementer direct messaging disabled by prompt rules)
-- Teammate model defaults to standard Opus (no 1M context). For one-off use, prefer `/model opus[1m]`. To make 1M context the default before starting Claude Code, set `export ANTHROPIC_DEFAULT_OPUS_MODEL='claude-opus-4-6[1m]'` using plain ASCII quotes (`'`), not smart quotes (`‘’`).
+- Teammate model defaults to standard Opus.


### PR DESCRIPTION
## Summary
- remove 1M-specific teammate guidance from the agent-team plugin
- keep the teammate model description generic to avoid directing users into a failing path
- bump the plugin patch version

## Testing
- verified the create-team skill and README no longer mention opus[1m] or ANTHROPIC_DEFAULT_OPUS_MODEL
- reviewed the resulting git diff