### PR TITLE
Remove create-team model override

### DIFF
--- a/agent-team-plugin/.claude-plugin/plugin.json
+++ b/agent-team-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-team-plugin",
   "description": "Agent team management - create, expand, and cleanup teams for worktree sessions",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "author": {
     "name": "Stefan Cho"
   }

--- a/agent-team-plugin/README.md
+++ b/agent-team-plugin/README.md
@@ -72,10 +72,6 @@ Goal → planner(spec) → TaskCreate → team-lead review → implementer(code)
 
 ## Configuration
 
-### Skill model and effort
-
-The `create team` skill is configured to run with `model: sonnet` and `effort: high` for more reliable team orchestration and fallback handling.
-
 ### Teammate model
 
 Teammates use the standard Opus model by default.

--- a/agent-team-plugin/skills/create-team/SKILL.md
+++ b/agent-team-plugin/skills/create-team/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: create-team
 description: Create an agent team with planner and implementer teammates for spec-driven development. Use when user says "create team", "팀 생성", "팀 만들어줘", "agent team", or wants to set up a planner+implementer workflow in a worktree session.
-model: sonnet
-effort: high
 allowed-tools: Bash, Agent, SendMessage, TeamCreate, TaskCreate, TaskList, TaskUpdate, Read, AskUserQuestion
 ---
 


### PR DESCRIPTION
## Summary
- remove the create-team skill's explicit `model` and `effort` overrides
- let the skill inherit the active session model instead of forcing Sonnet
- remove the README section that documented the override and bump the plugin patch version

## Testing
- verified the skill frontmatter no longer includes `model: sonnet` or `effort: high`
- verified the README no longer mentions the skill-specific model override
- reviewed the resulting git diff