### PR TITLE
Set create-team effort to medium

### DIFF
--- a/agent-team-plugin/skills/create-team/SKILL.md
+++ b/agent-team-plugin/skills/create-team/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: create-team
 description: Create an agent team with planner and implementer teammates for spec-driven development. Use when user says "create team", "팀 생성", "팀 만들어줘", "agent team", or wants to set up a planner+implementer workflow in a worktree session.
+effort: medium
 allowed-tools: Bash, Agent, SendMessage, TeamCreate, TaskCreate, TaskList, TaskUpdate, Read, AskUserQuestion
 ---
 


### PR DESCRIPTION
## Summary
- add an `effort: medium` override to the `create-team` skill
- keep model selection inherited from the active session
- reduce reasoning overhead for team setup while avoiding model-specific behavior changes

## Testing
- verified the skill frontmatter now includes only `effort: medium` as the runtime override
- reviewed the resulting git diff