### PR TITLE
skills: github-issue 통합 스킬 추가 (fetch/create/update + 이슈 템플릿)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,6 +16,7 @@
     "./skills/productivity/brain-storm",
     "./skills/productivity/session-resume",
     "./skills/productivity/llm-wiki",
+    "./skills/productivity/github-issue",
     "./skills/misc/hermes-runtime",
     "./skills/misc/setup-notification"
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ archived/                      # retired skills/plugins (not shipped)
 - **spec-driven** — writing-specs, writing-tasks, writing-flows, implement-with-test, test-commit-push-pr-clean
 - **agents** — create-team, split-work
 - **browser** — browser-walkthrough, computer-use-test, ui-prototype-preview
-- **productivity** — brain-storm, session-resume, llm-wiki
+- **productivity** — brain-storm, session-resume, llm-wiki, github-issue
 - **misc** — hermes-runtime, setup-notification
 
 ## SKILL.md conventions

--- a/skills/productivity/github-issue/SKILL.md
+++ b/skills/productivity/github-issue/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: github-issue
+description: "Unified GitHub issue workflow via the gh CLI — fetch an issue (body, labels, comments, image/video attachments) into the session, create a new issue from a template, or update an existing one (body, labels, state, comments). Handles the 404 that plain curl/WebFetch hits on GitHub attachment URLs by downloading with an auth token, and extracts viewable frames from video attachments. Use whenever the user mentions GitHub issues — 이슈 가져와, 이슈 조회, 이슈 등록, 이슈 생성, 이슈 만들어줘, 이슈 업데이트, 이슈 수정, 이슈 코멘트, 이슈 작업, fetch issue N, work on issue N, create an issue, update issue N, file a bug, /github-issue."
+---
+
+# GitHub Issue
+
+Operate on GitHub issues with the `gh` CLI. One skill, three operations — dispatch on the user's words or the argument:
+
+| User intent | Operation |
+| --- | --- |
+| "이슈 N 가져와 / 조회 / 작업", "fetch issue N", bare `/github-issue 94` | **Fetch** |
+| "이슈 등록 / 생성 / 만들어줘", "create issue", "file a bug" | **Create** |
+| "이슈 N 수정 / 업데이트 / 코멘트 / 닫아줘", "update issue N" | **Update** |
+
+If the intent is genuinely ambiguous, ask which operation — don't guess.
+
+## Common setup
+
+- Confirm `gh auth status` works once; if not, stop and tell the user to run `gh auth login`.
+- Default to the current repo. If the user names another repo, pass `-R <owner>/<repo>` to every `gh` call.
+
+## Fetch
+
+1. If no issue number was given, run `gh issue list`, show the open issues, and let the user pick.
+2. `gh issue view <N> --json number,title,state,labels,author,url,body,comments`
+3. Download every attachment found in the body and comments — **plain curl/WebFetch returns 404 on GitHub attachment URLs**. Follow [fetching.md](fetching.md) exactly (auth-token download, image Read, video → ffmpeg frames).
+4. Summarize in the conversation: issue number/title/labels, the problem or request in one or two lines, and what the attachments show.
+5. If the user is picking the issue up to work on it: locate the relevant code (grep for the symbols/strings the issue points at), state an initial hypothesis and candidate approach in a sentence or two — then stop. **Do not start editing code**; intake ends at understanding.
+
+## Create
+
+1. Pick a template, in this order:
+   - The repo's own `.github/ISSUE_TEMPLATE/*.md|*.yml` if present — list them and match by intent.
+   - Otherwise the bundled ones: [templates/bug-report.md](templates/bug-report.md), [templates/feature-request.md](templates/feature-request.md), [templates/task.md](templates/task.md).
+2. Fill the template from the conversation and any context the user gave. Write the issue in the language of the repo's existing issues (check a recent one if unsure). Ask only for fields you genuinely can't fill — don't interrogate.
+3. **Show the complete draft (title, body, labels) and wait for the user's OK before creating.** Filing an issue is outward-facing and visible to others; never skip this gate.
+4. Create with a body file so markdown survives quoting:
+
+   ```bash
+   gh issue create --title "<title>" --body-file <draft.md> --label "<labels>"
+   ```
+
+   Only pass labels that already exist in the repo (`gh label list`) — `gh` errors on unknown labels. Same rule for `--add-label` on update.
+
+5. Report the created issue URL.
+
+## Update
+
+1. Fetch the current state first (`gh issue view <N> --json title,body,labels,state`) — never edit blind.
+2. Show what will change as before → after (title/body diff, labels added/removed, state change) and **get confirmation before applying**.
+3. Apply with the matching command:
+   - body/title/labels: `gh issue edit <N> --title/--body-file/--add-label/--remove-label`
+   - comment: `gh issue comment <N> --body-file <comment.md>`
+   - state: `gh issue close <N> [--comment]` / `gh issue reopen <N>`
+4. Report the issue URL and what changed.
+
+## Anti-patterns
+
+- **WRONG**: `curl <attachment-url>` or WebFetch on `github.com/user-attachments/assets/...` → 404. **RIGHT**: download with `Authorization: token $(gh auth token)` per [fetching.md](fetching.md).
+- **WRONG**: Read a downloaded `.mp4` directly (wastes a turn, shows nothing). **RIGHT**: extract frames with ffmpeg and Read those.
+- **WRONG**: `gh issue create`/`edit` straight away with a body you never showed. **RIGHT**: full draft → user confirmation → apply.
+- **WRONG**: free-form issue body because the template "doesn't quite fit". **RIGHT**: pick the closest template and drop sections that are truly N/A.

--- a/skills/productivity/github-issue/fetching.md
+++ b/skills/productivity/github-issue/fetching.md
@@ -1,0 +1,61 @@
+# Downloading GitHub issue attachments
+
+GitHub issue/PR attachments (images AND videos) are hosted at URLs like
+`https://github.com/user-attachments/assets/<uuid>`. **Plain `curl` / `WebFetch`
+without credentials returns `404 Not Found`** — GitHub hides existence behind a
+404 rather than a 401/403. This file exists to avoid that failure.
+
+## What counts as an attachment URL
+
+Scan the issue **body and every comment** for:
+
+- markdown images: `![alt](url)`
+- HTML: `<img src="url">`, `<video src="url">`
+- bare GitHub-hosted URLs: `github.com/user-attachments/assets/...`,
+  `*.githubusercontent.com/...`, `github.com/<owner>/<repo>/assets/...`
+
+## Download with an auth header
+
+The same `user-attachments` URL can serve an image or a video; the content type
+isn't in the URL, so download first, then branch on what came back:
+
+```bash
+mkdir -p .design-artifacts/issue-<N>
+# Use an ABSOLUTE -o path — the Bash tool's cwd resets between calls, so a
+# relative path can land somewhere unexpected or report "No such file".
+out="$(pwd)/.design-artifacts/issue-<N>/attachment-1"
+curl -L -H "Authorization: token $(gh auth token)" "<url>" \
+  -o "$out" -w "%{http_code} %{content_type} %{size_download}\n"
+file "$out"   # confirm content type and that the bytes are complete
+```
+
+(`.design-artifacts/` is a scratch dir; create it if missing. It's often
+gitignored already — if not, just don't commit it.)
+
+## Handle each attachment by type
+
+- **Image** (`content_type` `image/*`) — rename with a matching extension
+  (`.jpg`/`.png`) and **Read** it so you actually see it.
+- **Video** (`content_type` `video/*`, e.g. screen recordings) — the Read tool
+  **cannot render video**; don't try to Read the `.mp4`/`.mov` directly. Extract
+  still frames with `ffmpeg` and Read those instead:
+
+  ```bash
+  mv "$out" "$out.mp4"
+  ffprobe -v error -show_entries format=duration -of csv=p=0 "$out.mp4"   # length
+  mkdir -p "$(dirname "$out")/frames"
+  ffmpeg -nostdin -loglevel error -i "$out.mp4" \
+    -vf "fps=1" "$(dirname "$out")/frames/frame_%03d.png"   # ~1 frame/sec
+  ```
+
+  A bug video usually only needs a few well-spaced frames (start / interaction
+  moment / end), so a denser `fps` is rarely worth it. If `ffprobe`/`ffmpeg`
+  errors with `moov atom not found`, the download was truncated — confirm the
+  on-disk size matches the `size_download` you logged and re-download to the
+  absolute path before retrying.
+
+## Failure handling
+
+- No attachments → skip this whole file.
+- A download still fails after the auth attempt → report it briefly and continue
+  text-only. Don't get stuck on one attachment.

--- a/skills/productivity/github-issue/templates/bug-report.md
+++ b/skills/productivity/github-issue/templates/bug-report.md
@@ -1,0 +1,32 @@
+<!-- Title: concise symptom, e.g. "Login button unresponsive on Safari" -->
+<!-- Labels: bug -->
+
+## Summary
+
+<!-- One or two sentences: what is broken, who it affects. -->
+
+## Environment
+
+<!-- Only what's relevant: OS / browser / app version / branch / commit. -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What should happen. -->
+
+## Actual Behavior
+
+<!-- What actually happens. Paste exact error messages verbatim. -->
+
+## Screenshots / Logs
+
+<!-- Attach images, recordings, or log excerpts. Drop the section if none. -->
+
+## Additional Context
+
+<!-- Regression? Workaround? Suspected cause or related code/issues. Drop if none. -->

--- a/skills/productivity/github-issue/templates/feature-request.md
+++ b/skills/productivity/github-issue/templates/feature-request.md
@@ -1,0 +1,18 @@
+<!-- Title: the capability, e.g. "Support CSV export in the report view" -->
+<!-- Labels: enhancement -->
+
+## Problem / Motivation
+
+<!-- What's painful or missing today, and for whom. The "why". -->
+
+## Proposed Solution
+
+<!-- What you want to happen. Sketch UX/API if it helps. -->
+
+## Alternatives Considered
+
+<!-- Other approaches or workarounds and why they fall short. Drop if none. -->
+
+## Additional Context
+
+<!-- Mockups, links, related issues, constraints. Drop if none. -->

--- a/skills/productivity/github-issue/templates/task.md
+++ b/skills/productivity/github-issue/templates/task.md
@@ -1,0 +1,20 @@
+<!-- Title: imperative action, e.g. "Migrate CI from CircleCI to GitHub Actions" -->
+<!-- Labels: task (or chore) -->
+
+## Goal
+
+<!-- What "done" delivers, in one or two sentences. -->
+
+## Context
+
+<!-- Why now: background, links to specs/discussions/parent issues. -->
+
+## Checklist
+
+- [ ]
+- [ ]
+- [ ]
+
+## Done Criteria
+
+<!-- How to verify it's complete: tests pass, doc updated, deployed, etc. -->

--- a/website/data/plugins.json
+++ b/website/data/plugins.json
@@ -158,6 +158,25 @@
       "uninstallCommand": ""
     },
     {
+      "id": "skills/productivity/github-issue",
+      "name": "github-issue",
+      "version": "0.1.0",
+      "description": "Unified GitHub issue workflow via the gh CLI — fetch an issue (body, labels, comments, image/video attachments) into the session, create a new issue from a template, or update an existing one (body, labels, state, comments). Handles the 404 that plain curl/WebFetch hits on GitHub attachment URLs by downloading with an auth token, and extracts viewable frames from video attachments.",
+      "author": "Stefan Cho",
+      "category": "productivity",
+      "components": {
+        "skills": [
+          "github-issue"
+        ],
+        "commands": [],
+        "hooks": false,
+        "mcpServers": []
+      },
+      "features": [],
+      "installCommand": "npx skills@latest add devstefancho/claude-plugins --skill github-issue -a claude-code -y",
+      "uninstallCommand": ""
+    },
+    {
       "id": "skills/productivity/llm-wiki",
       "name": "llm-wiki",
       "version": "0.1.0",


### PR DESCRIPTION
## 요약

GitHub 이슈를 가져오고(fetch), 템플릿 기반으로 생성하고(create), 수정하는(update) 작업을 하나로 묶은 통합 스킬 `skills/productivity/github-issue`를 추가합니다.

## 구현 내용

### 스킬 본체 (`SKILL.md`)
- 사용자 의도/인자로 fetch · create · update 세 작업을 디스패치 (예: `/github-issue 94` → fetch)
- **create는 항상 템플릿 기반**: 대상 레포의 `.github/ISSUE_TEMPLATE/*` 우선, 없으면 번들 템플릿 사용
- create/update 모두 전체 초안 또는 before→after를 보여주고 **사용자 확인 후에만** `gh issue create/edit` 실행
- 레포에 없는 라벨 전달 시 `gh`가 에러나는 실패 모드 명시 (`gh label list`로 확인)
- Anti-patterns 섹션 포함 (plain curl 404, .mp4 직접 Read, 무확인 생성, 자유 양식 본문)

### 첨부파일 처리 (`fetching.md`)
- 기존 user-level `issue-intake` 스킬에서 이관: attachment URL은 plain curl/WebFetch 시 404 → `gh auth token`으로 인증 다운로드
- 비디오 첨부는 ffmpeg로 프레임 추출 후 Read

### 이슈 템플릿 (`templates/`)
- `bug-report.md` / `feature-request.md` / `task.md` 3종

### 등록
- `.claude-plugin/plugin.json` `skills[]`, AGENTS.md productivity 카테고리, `website/data/plugins.json` (generate-plugin-data.js 재생성)

## 검증

- `jq . .claude-plugin/plugin.json` 통과
- SKILL.md frontmatter YAML 파싱 검증 (description 592자, 쌍따옴표 처리)
- `node scripts/generate-plugin-data.js` → 16개 스킬 정상 생성
- SKILL.md 63줄 (100줄 가이드 준수)

## 참고

- 기존 `~/.claude/skills/issue-intake`(user-level)는 그대로 두었습니다. 트리거가 겹치므로 이 스킬이 자리잡으면 정리 권장.
- intake의 grill-with-docs 자동 핸드오프는 의도적으로 제외 — 이 레포는 tool-agnostic이라 user-level 스킬 의존을 두지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)