### PR TITLE
skills: add executive-summary + skill-authoring checklist

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,6 +16,7 @@
     "./skills/productivity/brain-storm",
     "./skills/productivity/session-resume",
     "./skills/productivity/llm-wiki",
+    "./skills/productivity/executive-summary",
     "./skills/misc/hermes-runtime",
     "./skills/misc/setup-notification"
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,12 +29,12 @@ archived/                      # retired skills/plugins (not shipped)
 - **spec-driven** — writing-specs, writing-tasks, writing-flows, implement-with-test, test-commit-push-pr-clean
 - **agents** — create-team, split-work
 - **browser** — browser-walkthrough, computer-use-test, ui-prototype-preview
-- **productivity** — brain-storm, session-resume, llm-wiki
+- **productivity** — brain-storm, session-resume, llm-wiki, executive-summary
 - **misc** — hermes-runtime, setup-notification
 
 ## SKILL.md conventions
 
-Skills follow the style of [mattpocock/skills](https://github.com/mattpocock/skills). When creating or editing a skill:
+Skills follow the style of [mattpocock/skills](https://github.com/mattpocock/skills). **Before creating or editing any skill, read [docs/skill-authoring-checklist.md](docs/skill-authoring-checklist.md) and run through its gates — it is the pre-flight checklist for everything below.** When creating or editing a skill:
 
 **Frontmatter**
 - `name` (required): kebab-case, must match the skill directory name. Never rename casually — it is the installed-skill identity.
@@ -55,6 +55,8 @@ Skills follow the style of [mattpocock/skills](https://github.com/mattpocock/ski
 - **Hooks cannot be skills** (they are harness-invoked on events). A skill can *install* a hook: see `skills/misc/setup-notification` — a setup-skill that writes hooks into the user's `settings.json`.
 
 ## Adding a skill
+
+**First, read [docs/skill-authoring-checklist.md](docs/skill-authoring-checklist.md)** and use it as the gate for every step below.
 
 1. Create `skills/<category>/<name>/SKILL.md` with `name` + `description` frontmatter.
 2. Add any supporting files inside that dir.

--- a/docs/skill-authoring-checklist.md
+++ b/docs/skill-authoring-checklist.md
@@ -1,0 +1,62 @@
+# Skill Authoring Checklist
+
+스킬을 만들거나 고칠 때 매번 통과시킬 **실행 게이트**다. 규칙의 *근거와 상세*는 [AGENTS.md](../AGENTS.md)의 "SKILL.md conventions"가 SSOT이고, 이 문서는 그걸 체크박스로 옮긴 것 + 실제로 자주 밟는 함정 모음이다. 충돌하면 AGENTS.md가 이긴다.
+
+## 0. 시작 전
+
+- [ ] 같은 일을 하는 스킬이 이미 있는지 확인 — 있으면 새로 만들지 말고 그걸 고친다(트리거 충돌 방지).
+- [ ] 카테고리 결정: `spec-driven` / `agents` / `browser` / `productivity` / `misc`.
+- [ ] **출력이 주관적(글쓰기·요약·디자인)인가 객관적(파일 변환·코드 생성·고정 워크플로우)인가** 판단 → 객관적이면 정량 eval, 주관적이면 qualitative 리뷰로 검증 전략을 미리 정한다.
+
+## 1. Frontmatter
+
+- [ ] `name` = 디렉토리명, kebab-case. 함부로 rename 금지(설치 정체성).
+- [ ] `description`은 **2-문장 패턴**: 먼저 *무엇을 한다*, 그다음 `Use when [실제 사용자가 말하는 literal 어구]`. **한국어 트리거 어구 유지**, 1024자 이내.
+- [ ] description은 **valid YAML** — 값에 콜론(`:`)이 있으면 큰따옴표로 감싼다. (안 그러면 파싱이 깨져 `npx skills`에서 스킬이 조용히 사라진다.)
+- [ ] description을 **간결하게**. "Also fires…", "Proactively trigger…" 같은 문장을 줄줄이 붙이지 말 것 — 핵심 트리거만.
+
+> ⚠️ **함정 (이번 세션 교훈): 트리거 조건은 description에만 둔다.** 본문에 "When this fires / 언제 발동" 같은 섹션을 만들지 말 것. when-to-use 정보는 전부 description이 담당하고, 본문은 *어떻게 하는가*만 다룬다.
+
+## 2. Body
+
+레포 house style 골격 (PR #43 restyle된 스킬들이 일관되게 따르는 형태):
+
+- [ ] `# Title` 다음 **한 줄 essence** — 무엇을 하는지 + 스킬의 핵심 invariant를 그 한 줄에 박는다 (예: writing-tasks "…never stored", browser-walkthrough "…핵심은 대화 프로토콜이다").
+- [ ] 상단에 **`## Hard Rules` 블록.** 불릿마다 **bold 리드 문구.** 그다음 em-dash로 *이유·결과*를 붙인다 ("**Never code without a task definition.** … — this kills aimless coding").
+- [ ] 결정·상태→행동 매핑은 산문이 아니라 **표(table)**로.
+- [ ] 워크플로우는 **numbered phases + `- [ ]` 체크리스트**를 phase 간 게이트로.
+- [ ] 끝부분에 **`## Anti-patterns`** (WRONG/RIGHT), 필요하면 **`## Boundaries`** (스코프·out-of-scope·페어 스킬·"keep outputs tight").
+- [ ] **100줄 이내.** 넘치면 sibling `.md`로 분리하고 한 단계 깊이로 링크(progressive disclosure). **behavior-critical 디테일은 삭제하지 말고 이동.**
+- [ ] 규칙마다 **"왜"를 설명**한다. 대문자 MUST/NEVER 남발은 yellow flag — 이유를 적어 모델이 스스로 판단하게.
+
+> ⚠️ **함정 (이번 세션 교훈): 같은 아이디어를 여러 곳에 중복 서술하지 말 것.** "원칙 섹션 + 별도 강조 섹션 + Anti-patterns"에 같은 규칙을 3번 쓰면 길어지기만 한다. **한 아이디어 = 한 곳.**
+
+- [ ] **Anti-patterns(WRONG/RIGHT)는 *알려진 실패모드가 있을 때만*** 둔다. 위 원칙의 재탕이 아니라, 원칙만으로는 안 잡히는 고유 실패모드만 대조로.
+- [ ] 일화·배경 fluff 제거("이 사용자는 ~한 적이 있다" 류). 동작을 바꾸지 않는 문장은 뺀다.
+
+## 3. 지원 파일 (scripts / templates / references)
+
+- [ ] 모두 스킬 디렉토리 안에 두고 SKILL.md **기준 상대경로**로 링크.
+- [ ] 매 호출마다 똑같이 다시 만들게 될 산출물(HTML 리포트, 빌드 스크립트 등)은 **템플릿/스크립트로 번들**해 재작성을 막는다.
+- [ ] **파생 인덱스·중복 파일을 만들지 말 것 (SSOT).** 한 정보는 한 곳에만.
+
+## 4. 등록 & 검증
+
+- [ ] `.claude-plugin/plugin.json`의 `skills[]`에 경로 등록.
+- [ ] `jq . .claude-plugin/plugin.json` — JSON 유효성.
+- [ ] frontmatter YAML 파싱 확인 (name·description 존재, description ≤ 1024자).
+- [ ] `wc -l SKILL.md` — 100줄 이내 재확인.
+- [ ] `scripts/validate-plugins.sh` 있으면 통과.
+
+## 5. 테스트
+
+- [ ] 현실적인 프롬프트 1~3개로 **with-skill 실행(subagent)**해 스킬이 실제로 의도대로 동작하는지 본다.
+- [ ] 객관적 출력이면 baseline 대비 정량 benchmark, 주관적 출력이면 사람 리뷰(eval-viewer).
+- [ ] (선택) description triggering 최적화 루프로 발동 정확도 튜닝.
+
+> ⚠️ **함정 (이번 세션 교훈): "완료" 선언 전에 functional sanity test 한 번은 돌린다.** 파일만 쓰고 끝내지 말고, 스킬을 실제 프롬프트에 태워 결과를 눈으로 확인한 뒤 마무리.
+
+## 6. 마무리
+
+- [ ] 변경이 사용자 요청 라인에 직접 추적되는지(불필요한 인접 수정 없음) 확인.
+- [ ] 커밋·푸시·PR은 **요청받았을 때만**.

--- a/skills/productivity/executive-summary/SKILL.md
+++ b/skills/productivity/executive-summary/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: executive-summary
+description: Compresses a long output, report, or analysis into a one-page executive (CEO/CTO) brief — conclusion first, key points only, technical detail translated into business impact. Use when the user wants the gist of something too long for a decision-maker, with phrases like 내용이 너무 많아서 읽기 힘들다, 한눈에 안 들어온다, 다 읽기 귀찮으니 요약해줘, CEO/CTO에게 보고하듯, 한 페이지로 정리해줘, 핵심만 압축해서 알려줘, 정리해줘, 요약해줘.
+allowed-tools: Read, Write, Bash
+---
+
+# Executive Summary
+
+Compress something long into a one-page brief a CEO or CTO can absorb at a glance — without dropping the facts they need to decide.
+
+## Find the source first
+
+Usually the source is the immediately preceding long response in this conversation. It can also be a file or doc the user points to, or — when the request is to *produce* a result as a one-pager — the work you're about to finish. Summarize that, don't invent.
+
+## Hard Rules
+
+The reader **decides**, they don't implement — that drives every rule:
+
+- **Lead with the answer.** The first line is the bottom line — the conclusion or the decision needed, never background or methodology. Re-structure around the decision; don't just shrink the source's section order.
+- **Translate, don't transcribe.** Turn technical detail into impact — what changed, why it matters, what it costs, what's at risk — and drop implementation minutiae.
+- **Keep the load-bearing facts.** One page tempts over-cutting, the more common failure: drop the specifics a decision rests on and the reader just asks again. Preserve the key numbers, the blocker, the cost, the deadline, the recommended option. When you do leave detail out, point to where it lives ("상세 내역은 원문 참고") instead of dropping it silently.
+- **One page, scannable.** Roughly one screen (~150–250 words), short bullets, one idea per line. If it won't fit, prioritize harder — don't shrink the font.
+
+## Structure
+
+Match the user's language (Korean by default, 존댓말·간결체). Use this template and omit any section that would be empty:
+
+```
+# [한 줄 제목 = 결론]
+
+**한 줄 요약** — [의사결정자가 가장 먼저 알아야 할 1–2문장]
+
+## 핵심 포인트
+- [영향·결과 중심, 3–5개, 각 한 줄]
+
+## 결정 / 다음 액션
+- [필요한 승인·결정·다음 단계, 1–3개]
+
+## 리스크·비용 (있을 때만)
+- [블로커, 비용, 일정 리스크]
+```
+
+Comparing options? Use a table instead of bullets:
+
+```
+| 항목 | 옵션 A | 옵션 B |
+|------|--------|--------|
+| 비용 | …      | …      |
+```
+
+## Output medium
+
+- **Default — inline.** Render the brief directly in your reply. Most "정리해줘 / 알려줘" requests want it right here — don't make a file unless asked.
+- **HTML one-pager** — when the user says "html로", "열어줘", "보기 쉽게", or wants something shareable or printable. Steps:
+  1. `cp templates/onepager.html "$TMPDIR/exec-brief.html"` (fall back to `/tmp` if `$TMPDIR` is unset).
+  2. Fill the editable regions (marked with HTML comments); delete sections you don't use.
+  3. `open "$TMPDIR/exec-brief.html"` (macOS).
+
+## Anti-patterns
+
+- **WRONG**: 한 페이지에 맞추려고 핵심 숫자·블로커·비용까지 잘라내 "느낌만" 남긴다 → 독자가 다시 물어본다. **RIGHT**: 덜 중요한 디테일을 빼되 의사결정에 필요한 load-bearing 사실은 남기고, 생략분은 "원문 참고"로 가리킨다.
+- **WRONG**: 원문의 소제목 순서를 그대로 줄여 베끼고 결론을 맨 끝에 둔다. **RIGHT**: 결론을 첫 줄에 올리고 의사결정자 관점(결론 → 근거 → 액션)으로 재구성한다.
+
+## Boundaries
+
+Compression only — this reshapes content that already exists into a brief, not new research or analysis. It pairs naturally *after* any skill that emits a long artifact (audits, roadmaps, reports). Keep it to one page; if the source genuinely needs deeper work, that's a separate task, not a longer summary.

--- a/skills/productivity/executive-summary/templates/onepager.html
+++ b/skills/productivity/executive-summary/templates/onepager.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<!--
+  Executive one-pager template (self-contained, print-friendly).
+  Fill the regions marked  <!-- EDIT ... -->  and delete any section you don't need.
+  Keep the whole thing to ONE page — if it overflows on screen/print, cut content.
+-->
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><!-- EDIT:TITLE -->경영 보고<!-- /EDIT --></title>
+<style>
+  :root {
+    --ink: #1a1a1a;
+    --muted: #6b7280;
+    --line: #e5e7eb;
+    --accent: #1d4ed8;
+    --accent-soft: #eff6ff;
+    --bg: #f3f4f6;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo",
+                 "Segoe UI", "Noto Sans KR", sans-serif;
+    color: var(--ink);
+    background: var(--bg);
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+  .page {
+    max-width: 820px;
+    margin: 32px auto;
+    background: #fff;
+    padding: 48px 56px;
+    border-radius: 10px;
+    box-shadow: 0 1px 3px rgba(0,0,0,.08), 0 8px 24px rgba(0,0,0,.04);
+  }
+  header { border-bottom: 2px solid var(--ink); padding-bottom: 16px; margin-bottom: 24px; }
+  h1 { font-size: 26px; line-height: 1.25; margin: 0 0 6px; letter-spacing: -.01em; }
+  .meta { color: var(--muted); font-size: 13px; }
+  .bottomline {
+    background: var(--accent-soft);
+    border-left: 4px solid var(--accent);
+    padding: 14px 18px;
+    border-radius: 0 6px 6px 0;
+    margin: 0 0 26px;
+    font-size: 16px;
+  }
+  .bottomline strong { color: var(--accent); }
+  h2 {
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    color: var(--muted);
+    margin: 26px 0 10px;
+  }
+  ul { margin: 0; padding-left: 20px; }
+  li { margin: 6px 0; }
+  li::marker { color: var(--accent); }
+  table { width: 100%; border-collapse: collapse; font-size: 14px; margin-top: 6px; }
+  th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--line); }
+  th { color: var(--muted); font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: .04em; }
+  .footnote { margin-top: 28px; padding-top: 12px; border-top: 1px solid var(--line); color: var(--muted); font-size: 12px; }
+  @media print {
+    body { background: #fff; }
+    .page { margin: 0; box-shadow: none; border-radius: 0; max-width: none; padding: 24px 28px; }
+  }
+</style>
+</head>
+<body>
+  <main class="page">
+    <header>
+      <h1><!-- EDIT:TITLE -->한 줄 제목 = 결론<!-- /EDIT --></h1>
+      <div class="meta"><!-- EDIT:META -->보고 대상 · 날짜<!-- /EDIT --></div>
+    </header>
+
+    <p class="bottomline">
+      <strong>한 줄 요약</strong> —
+      <!-- EDIT:BOTTOMLINE -->의사결정자가 가장 먼저 알아야 할 1–2문장.<!-- /EDIT -->
+    </p>
+
+    <!-- EDIT:KEYPOINTS (삭제 가능) -->
+    <h2>핵심 포인트</h2>
+    <ul>
+      <li>영향·결과 중심, 각 한 줄.</li>
+      <li>두 번째 포인트.</li>
+      <li>세 번째 포인트.</li>
+    </ul>
+    <!-- /EDIT -->
+
+    <!-- EDIT:DECISIONS (삭제 가능) -->
+    <h2>결정 / 다음 액션</h2>
+    <ul>
+      <li>필요한 승인·결정·다음 단계.</li>
+    </ul>
+    <!-- /EDIT -->
+
+    <!-- EDIT:COMPARE (옵션 비교가 없으면 이 블록 통째로 삭제) -->
+    <h2>비교</h2>
+    <table>
+      <thead><tr><th>항목</th><th>옵션 A</th><th>옵션 B</th></tr></thead>
+      <tbody>
+        <tr><td>비용</td><td>—</td><td>—</td></tr>
+        <tr><td>리스크</td><td>—</td><td>—</td></tr>
+      </tbody>
+    </table>
+    <!-- /EDIT -->
+
+    <!-- EDIT:RISKS (리스크가 없으면 이 블록 통째로 삭제) -->
+    <h2>리스크 · 비용</h2>
+    <ul>
+      <li>블로커 / 비용 / 일정 리스크.</li>
+    </ul>
+    <!-- /EDIT -->
+
+    <!-- EDIT:FOOTNOTE (생략 가능) -->
+    <p class="footnote">상세 내역은 원문 참고.</p>
+    <!-- /EDIT -->
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## What

Adds a new **executive-summary** skill and a repo-wide **skill-authoring checklist**, derived from analyzing the user's past Claude Code prompts.

### `skills/productivity/executive-summary/`
Compresses a long output/report/analysis into a **one-page CEO/CTO brief** — conclusion first, key points only, technical detail translated into business impact, without dropping the facts a decision needs.
- Trigger phrases mined from real prompts: `내용이 너무 많아서 읽기 힘들다`, `한눈에 안 들어온다`, `CEO/CTO에게 보고하듯`, `한 페이지로 정리해줘`, `핵심만 압축`, `정리해줘`, `요약해줘`.
- Bundles a self-contained HTML one-pager template (`templates/onepager.html`) for the "html로 열어줘" path.
- Follows the repo house style (one-line essence + invariant → `## Hard Rules` → tables → `## Anti-patterns` → `## Boundaries`), 66 lines.

### `docs/skill-authoring-checklist.md`
Pre-flight gate distilled from AGENTS.md conventions + session-learned pitfalls:
- triggers belong in `description` only (no `When this fires` body section)
- one idea = one place (no triple-restating across principles/section/anti-patterns)
- run a functional sanity test before declaring done

AGENTS.md now **requires reading the checklist** before creating/editing any skill (conventions intro + Adding-a-skill step 0), and lists `executive-summary` under productivity.

## Verification
- `jq` valid; both `executive-summary` and `github-issue` (merged from main) registered in `plugin.json`.
- All registered skill dirs have `SKILL.md`.
- `executive-summary` frontmatter parses as valid YAML, description 371 chars (≤1024).
- Functional sanity test: ran the skill on a realistic long status report; produced a conclusion-first one-page brief preserving load-bearing numbers.

## Notes
- No `VERSION`/`CHANGELOG` bump — this repo versions only via `plugin.json`, and per repo convention adding a skill does not bump it (matches the writing-flows / github-issue adds).
- Merged latest `main` (github-issue, PR #47); list conflicts resolved to keep both skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)